### PR TITLE
Add operations to transactions + CreateAccount op

### DIFF
--- a/lib/tx_build/account_id.ex
+++ b/lib/tx_build/account_id.ex
@@ -1,0 +1,33 @@
+defmodule Stellar.TxBuild.AccountID do
+  @moduledoc """
+  `AccountID` struct definition.
+  """
+  alias Stellar.KeyPair
+  alias StellarBase.XDR.{AccountID, PublicKey, PublicKeyType, UInt256}
+
+  @behaviour Stellar.TxBuild.XDR
+
+  @type t :: %__MODULE__{account_id: String.t()}
+
+  defstruct [:account_id]
+
+  @impl true
+  def new(account_id, opts \\ [])
+
+  def new(account_id, _opts) when byte_size(account_id) == 56 do
+    %__MODULE__{account_id: account_id}
+  end
+
+  def new(_account_id, _opts), do: {:error, :invalid_account_id}
+
+  @impl true
+  def to_xdr(%__MODULE__{account_id: account_id}) do
+    type = PublicKeyType.new(:PUBLIC_KEY_TYPE_ED25519)
+
+    account_id
+    |> KeyPair.raw_ed25519_public_key()
+    |> UInt256.new()
+    |> PublicKey.new(type)
+    |> AccountID.new()
+  end
+end

--- a/lib/tx_build/amount.ex
+++ b/lib/tx_build/amount.ex
@@ -1,0 +1,34 @@
+defmodule Stellar.TxBuild.Amount do
+  @moduledoc """
+  `Amount` struct definition.
+  """
+  alias StellarBase.XDR.Int64
+
+  @behaviour Stellar.TxBuild.XDR
+
+  @unit 10_000_000
+
+  @type amount :: non_neg_integer() | float()
+
+  @type t :: %__MODULE__{amount: amount(), raw_amount: non_neg_integer()}
+
+  defstruct [:amount, :raw_amount]
+
+  @impl true
+  def new(amount, opts \\ [])
+
+  def new(amount, _opts) when is_integer(amount) do
+    %__MODULE__{amount: amount, raw_amount: amount * @unit}
+  end
+
+  def new(amount, _opts) when is_float(amount) do
+    %__MODULE__{amount: amount, raw_amount: trunc(amount * @unit)}
+  end
+
+  def new(_amount, _opts), do: {:error, :invalid_amount}
+
+  @impl true
+  def to_xdr(%__MODULE__{raw_amount: raw_amount}) do
+    Int64.new(raw_amount)
+  end
+end

--- a/lib/tx_build/create_account.ex
+++ b/lib/tx_build/create_account.ex
@@ -1,0 +1,29 @@
+defmodule Stellar.TxBuild.CreateAccount do
+  @moduledoc """
+  `CreateAccountOp` struct definition.
+  """
+  alias Stellar.TxBuild.{AccountID, Amount}
+  alias StellarBase.XDR.Operations.CreateAccount
+
+  @behaviour Stellar.TxBuild.XDR
+
+  @type t :: %__MODULE__{destination: String.t(), starting_balance: non_neg_integer()}
+
+  defstruct [:destination, :starting_balance]
+
+  @impl true
+  def new(destination, starting_balance) do
+    %__MODULE__{
+      destination: AccountID.new(destination),
+      starting_balance: Amount.new(starting_balance)
+    }
+  end
+
+  @impl true
+  def to_xdr(%__MODULE__{destination: destination, starting_balance: starting_balance}) do
+    CreateAccount.new(
+      AccountID.to_xdr(destination),
+      Amount.to_xdr(starting_balance)
+    )
+  end
+end

--- a/lib/tx_build/operation.ex
+++ b/lib/tx_build/operation.ex
@@ -1,0 +1,47 @@
+defmodule Stellar.TxBuild.Operation do
+  @moduledoc """
+  `Operation` struct definition.
+  """
+  alias Stellar.TxBuild.CreateAccount
+  alias StellarBase.XDR.{Operation, OperationBody, OperationType, OptionalMuxedAccount}
+
+  @behaviour Stellar.TxBuild.XDR
+
+  @type op_body :: CreateAccount.t()
+
+  @type source_account :: String.t() | nil
+
+  @type t :: %__MODULE__{op_body: op_body(), source_account: source_account()}
+
+  defstruct [:op_body, :source_account]
+
+  @impl true
+  def new(op_body, opts \\ []) do
+    source_account = Keyword.get(opts, :source_account, nil)
+    %__MODULE__{op_body: op_body, source_account: source_account}
+  end
+
+  @impl true
+  def to_xdr(%__MODULE__{op_body: %CreateAccount{} = op_body, source_account: source_account}) do
+    op_type = OperationType.new(:CREATE_ACCOUNT)
+
+    op_body
+    |> CreateAccount.to_xdr()
+    |> operation_xdr(op_type, source_account)
+  end
+
+  def to_xdr(_operation), do: {:error, :invalid_operation}
+
+  @spec operation_xdr(
+          op_body :: struct(),
+          op_type :: struct(),
+          source_account :: source_account()
+        ) :: Operation.t()
+  defp operation_xdr(op_body, op_type, source_account) do
+    source_account = OptionalMuxedAccount.new(source_account)
+
+    op_body
+    |> OperationBody.new(op_type)
+    |> (&Operation.new(source_account, &1)).()
+  end
+end

--- a/lib/tx_build/operations.ex
+++ b/lib/tx_build/operations.ex
@@ -2,6 +2,7 @@ defmodule Stellar.TxBuild.Operations do
   @moduledoc """
   `Operations` struct definition.
   """
+  alias Stellar.TxBuild.Operation
   alias StellarBase.XDR.Operations
 
   @behaviour Stellar.TxBuild.XDR
@@ -19,11 +20,13 @@ defmodule Stellar.TxBuild.Operations do
 
   @impl true
   def to_xdr(%__MODULE__{operations: operations}) do
-    Operations.new(operations)
+    operations
+    |> Enum.map(&Operation.to_xdr/1)
+    |> Operations.new()
   end
 
-  @spec add(operations :: t(), operation :: any()) :: t()
-  def add(%__MODULE__{operations: operations}, operation) do
+  @spec add(operations :: t(), operation :: Operation.t()) :: t()
+  def add(%__MODULE__{operations: operations}, %Operation{} = operation) do
     %__MODULE__{operations: operations ++ [operation]}
   end
 end

--- a/lib/tx_build/tx_build.ex
+++ b/lib/tx_build/tx_build.ex
@@ -5,6 +5,7 @@ defmodule Stellar.TxBuild do
   alias Stellar.TxBuild.{
     Account,
     Memo,
+    Operation,
     Operations,
     Signature,
     TimeBounds,
@@ -43,13 +44,30 @@ defmodule Stellar.TxBuild do
     %{tx_build | tx: transaction}
   end
 
-  @spec add_operation(tx_build :: t(), operation :: any()) :: t()
-  def add_operation(%__MODULE__{tx: tx} = tx_build, operation) do
+  @spec add_operation(tx_build :: t(), operations :: operations()) :: t()
+  def add_operation(%__MODULE__{} = tx_build, []), do: tx_build
+
+  def add_operation(%__MODULE__{} = tx_build, [operation | operations]) do
+    tx_build
+    |> add_operation(operation)
+    |> add_operation(operations)
+  end
+
+  def add_operation(%__MODULE__{tx: tx} = tx_build, op_body) do
+    operation = Operation.new(op_body)
     transaction = %{tx | operations: Operations.add(tx.operations, operation)}
     %{tx_build | tx: transaction}
   end
 
-  @spec sign(tx_build :: t(), keypair :: tuple()) :: t()
+  @spec sign(tx_build :: t(), keypairs :: keypairs()) :: t()
+  def sign(%__MODULE__{} = tx_build, []), do: tx_build
+
+  def sign(%__MODULE__{} = tx_build, [signature | signatures]) do
+    tx_build
+    |> sign(signature)
+    |> sign(signatures)
+  end
+
   def sign(%__MODULE__{signatures: signatures} = tx_build, {public_key, secret}) do
     signature = Signature.new(public_key, secret)
     %{tx_build | signatures: signatures ++ [signature]}

--- a/lib/tx_build/tx_build.ex
+++ b/lib/tx_build/tx_build.ex
@@ -15,6 +15,14 @@ defmodule Stellar.TxBuild do
 
   @type signatures :: list(Signature.t())
 
+  @type keypair :: {String.t(), String.t()}
+
+  @type keypairs :: list(keypair())
+
+  @type operation :: CreateAccount.t()
+
+  @type operations :: operation() | list(operation())
+
   @type t :: %__MODULE__{
           tx: Transaction.t(),
           signatures: signatures(),

--- a/test/tx_build/account_id_test.exs
+++ b/test/tx_build/account_id_test.exs
@@ -1,0 +1,30 @@
+defmodule Stellar.TxBuild.AccountIDTest do
+  use ExUnit.Case
+
+  import Stellar.Test.XDRFixtures, only: [account_id_xdr: 1]
+  alias Stellar.TxBuild.AccountID
+
+  setup do
+    account_id = "GD726E62G6G4ANHWHIQTH5LNMFVF2EQSEXITB6DZCCTKVU6EQRRE2SJS"
+
+    %{
+      account_id: account_id,
+      xdr: account_id_xdr(account_id)
+    }
+  end
+
+  test "new/2", %{account_id: account_id} do
+    %AccountID{account_id: ^account_id} = AccountID.new(account_id)
+  end
+
+  test "new/2 invalid_key" do
+    {:error, :invalid_account_id} = AccountID.new("ABCD")
+  end
+
+  test "to_xdr/1", %{xdr: xdr, account_id: account_id} do
+    ^xdr =
+      account_id
+      |> AccountID.new()
+      |> AccountID.to_xdr()
+  end
+end

--- a/test/tx_build/amount_test.exs
+++ b/test/tx_build/amount_test.exs
@@ -1,0 +1,27 @@
+defmodule Stellar.TxBuild.AmountTest do
+  use ExUnit.Case
+
+  alias Stellar.TxBuild.Amount
+  alias StellarBase.XDR.Int64
+
+  test "new/2 integer" do
+    %Amount{amount: 7, raw_amount: 70_000_000} = Amount.new(7)
+  end
+
+  test "new/2 float" do
+    %Amount{amount: 3.141516, raw_amount: 31_415_160} = Amount.new(3.141516)
+  end
+
+  test "new/2 invalid" do
+    {:error, :invalid_amount} = Amount.new("123")
+  end
+
+  test "to_xdr/1" do
+    amount_xdr = Int64.new(70_000_000)
+
+    ^amount_xdr =
+      7
+      |> Amount.new()
+      |> Amount.to_xdr()
+  end
+end

--- a/test/tx_build/create_account_test.exs
+++ b/test/tx_build/create_account_test.exs
@@ -1,0 +1,37 @@
+defmodule Stellar.TxBuild.CreateAccountTest do
+  use ExUnit.Case
+
+  import Stellar.Test.XDRFixtures, only: [create_account_op_xdr: 2]
+
+  alias Stellar.TxBuild.{AccountID, Amount, CreateAccount}
+
+  setup do
+    public_key = "GD726E62G6G4ANHWHIQTH5LNMFVF2EQSEXITB6DZCCTKVU6EQRRE2SJS"
+    amount = 100
+
+    %{
+      public_key: public_key,
+      amount: amount,
+      destination: AccountID.new(public_key),
+      starting_balance: Amount.new(amount),
+      xdr: create_account_op_xdr(public_key, amount)
+    }
+  end
+
+  test "new/2", %{
+    public_key: public_key,
+    destination: destination,
+    starting_balance: starting_balance,
+    amount: amount
+  } do
+    %CreateAccount{destination: ^destination, starting_balance: ^starting_balance} =
+      CreateAccount.new(public_key, amount)
+  end
+
+  test "to_xdr/1", %{xdr: xdr, public_key: public_key, amount: amount} do
+    ^xdr =
+      public_key
+      |> CreateAccount.new(amount)
+      |> CreateAccount.to_xdr()
+  end
+end

--- a/test/tx_build/operation_test.exs
+++ b/test/tx_build/operation_test.exs
@@ -1,0 +1,64 @@
+defmodule Stellar.TxBuild.FakeOperation do
+  @moduledoc false
+
+  @behaviour Stellar.TxBuild.XDR
+
+  defstruct [:destination, :balance]
+
+  @impl true
+  def new(destination, balance) do
+    %__MODULE__{destination: destination, balance: balance}
+  end
+
+  @impl true
+  def to_xdr(_op) do
+    :ok
+  end
+end
+
+defmodule Stellar.TxBuild.OperationTest do
+  use ExUnit.Case
+
+  import Stellar.Test.XDRFixtures, only: [create_account_op_xdr: 2, operation_xdr: 1]
+
+  alias Stellar.TxBuild.{Operation, CreateAccount, FakeOperation}
+
+  setup do
+    amount = 100
+    public_key = "GD726E62G6G4ANHWHIQTH5LNMFVF2EQSEXITB6DZCCTKVU6EQRRE2SJS"
+    source_account = "GBFJE2R5ZXJYMVUJHFPHKIQO3PSTKCC42AGYY3WPEY3NPOBYX2NK542R"
+    op_body_xdr = create_account_op_xdr(public_key, amount)
+
+    %{
+      public_key: public_key,
+      amount: amount,
+      source_account: source_account,
+      op_body: CreateAccount.new(public_key, amount),
+      xdr: operation_xdr(op_body_xdr)
+    }
+  end
+
+  test "new/2", %{op_body: op_body} do
+    %Operation{op_body: ^op_body, source_account: nil} = Operation.new(op_body)
+  end
+
+  test "new/2 with source_account", %{op_body: op_body, source_account: source_account} do
+    %Operation{op_body: ^op_body, source_account: ^source_account} =
+      Operation.new(op_body, source_account: source_account)
+  end
+
+  test "to_xdr/1", %{xdr: xdr, op_body: op_body} do
+    ^xdr =
+      op_body
+      |> Operation.new()
+      |> Operation.to_xdr()
+  end
+
+  test "to_xdr/1 invalid_operation" do
+    {:error, :invalid_operation} =
+      "ABCD"
+      |> FakeOperation.new(10)
+      |> Operation.new()
+      |> Operation.to_xdr()
+  end
+end

--- a/test/tx_build/operations_test.exs
+++ b/test/tx_build/operations_test.exs
@@ -2,18 +2,24 @@ defmodule Stellar.TxBuild.OperationsTest do
   use ExUnit.Case
 
   alias StellarBase.XDR.Operations, as: OperationsXDR
-  alias Stellar.TxBuild.Operations
+  alias Stellar.TxBuild.{Operation, Operations, CreateAccount}
 
   setup do
-    %{operations: Operations.new()}
+    op_body = CreateAccount.new("GBTG2POJVVSRBQSZVA3IYJEZJQLPTIVVYOYRLTZEAEFBMVP72ZTQYA2V", 1.5)
+    operation = Operation.new(op_body)
+
+    %{
+      operation: operation,
+      operations: Operations.new()
+    }
   end
 
   test "new/2" do
     %Operations{operations: []} = Operations.new()
   end
 
-  test "add/1", %{operations: operations} do
-    %Operations{operations: [:test]} = Operations.add(operations, :test)
+  test "add/1", %{operations: operations, operation: operation} do
+    %Operations{operations: [^operation]} = Operations.add(operations, operation)
   end
 
   test "to_xdr/1", %{operations: operations} do


### PR DESCRIPTION
**This PR:** 
* Allows adding operations to transactions
* Implements the first operation: CreateAccount

----
This is how the Tx construction looks so far:

```elixir
alias Stellar.{KeyPair, TxBuild}
alias Stellar.TxBuild.{Account, CreateAccount}

# origin account
account = Account.new("GD726E62G6G4ANHWHIQTH5LNMFVF2EQSEXITB6DZCCTKVU6EQRRE2SJS")

# operation
op = CreateAccount.new("GBTG2POJVVSRBQSZVA3IYJEZJQLPTIVVYOYRLTZEAEFBMVP72ZTQYA2V", 1.5)

# signers
keypair = KeyPair.from_secret("SACHJRYLY43MUXRRCRFA6CZ5ZW5JVPPR4CWYWIX6BWRAOHOFVPVYDO5Z")
keypair2 = KeyPair.from_secret("SBRJB6SEMLCMPGIBUY45HSMBNJ42WGFBOSJVJP34Y75FQJSGIMPRPXG2")

tx =
  account
  |> TxBuild.new()
  |> TxBuild.add_operation(op)
  |> TxBuild.sign([keypair, keypair2])

tx_base_64 = TxBuild.envelope(tx)

Output: ===========
AAAAAgAAAAD/rxPaN43ANPY6ITP1bWFqXRISJdEw+HkQpqrTxIRiTQAAAGQADqyoAAAAAQAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAGZtPcmtZRDCWag2jCSZTBb5orXDsRXPJAEKFlX/1mcMAAAAAADk4cAAAAAAAAAAAsSEYk0AAABAHPuzUntyW8QsTZ5uRNeyPQ8ajoVWdeU+ijFlGzDK3cTRa63lbR5iKGAolmVnD4QQ9BaopxRXl88+qxmPl+nmBP/WZwwAAABAGky9LPb7TA/CS7C3PlSOVDgriLrM22cpvOyGQ1wb1v1EOMsJb7FGQb6xtLBKBgsfYC5QhiVM/Csb8ua0Y8/gAA==
```

![image](https://user-images.githubusercontent.com/1649973/144129599-31c5004a-0fdd-4ce7-80b5-9bb23c551c66.png)
