### PR TITLE
Extend validation functions to any operation

### DIFF
--- a/lib/tx_build/create_account.ex
+++ b/lib/tx_build/create_account.ex
@@ -1,13 +1,13 @@
 defmodule Stellar.TxBuild.CreateAccount do
   @moduledoc """
-  `CreateAccountOp` struct definition.
+  Creates and funds a new account with the specified starting balance.
   """
+  import Stellar.TxBuild.OpValidate
+
   alias Stellar.TxBuild.{AccountID, Amount}
   alias StellarBase.XDR.{OperationBody, OperationType, Operations.CreateAccount}
 
   @behaviour Stellar.TxBuild.XDR
-
-  @type validation :: {:ok, any()} | {:error, atom()}
 
   @type source_account :: String.t() | nil
 
@@ -27,8 +27,8 @@ defmodule Stellar.TxBuild.CreateAccount do
     starting_balance = Keyword.get(args, :starting_balance)
     source_account = Keyword.get(args, :source_account)
 
-    with {:ok, destination} <- validate_destination(destination),
-         {:ok, starting_balance} <- validate_starting_balance(starting_balance) do
+    with {:ok, destination} <- validate_account_id({:destination, destination}),
+         {:ok, starting_balance} <- validate_amount({:starting_balance, starting_balance}) do
       %__MODULE__{
         destination: destination,
         starting_balance: starting_balance,
@@ -48,21 +48,5 @@ defmodule Stellar.TxBuild.CreateAccount do
     destination
     |> CreateAccount.new(amount)
     |> OperationBody.new(op_type)
-  end
-
-  @spec validate_destination(destination :: String.t()) :: validation()
-  defp validate_destination(destination) do
-    case AccountID.new(destination) do
-      %AccountID{} = destination -> {:ok, destination}
-      _error -> {:error, :invalid_destination}
-    end
-  end
-
-  @spec validate_starting_balance(starting_balance :: String.t()) :: validation()
-  defp validate_starting_balance(starting_balance) do
-    case Amount.new(starting_balance) do
-      %Amount{} = starting_balance -> {:ok, starting_balance}
-      _error -> {:error, :invalid_starting_balance}
-    end
   end
 end

--- a/lib/tx_build/op_validate.ex
+++ b/lib/tx_build/op_validate.ex
@@ -1,0 +1,35 @@
+defmodule Stellar.TxBuild.OpValidate do
+  @moduledoc """
+  Validates operation components.
+  """
+  alias Stellar.TxBuild.{Account, AccountID, Amount}
+
+  @type account_id :: String.t()
+  @type value :: account_id() | asset() | number()
+  @type component :: {atom(), value()}
+  @type validation :: {:ok, any()} | {:error, atom()}
+
+  @spec validate_account_id(component :: component()) :: validation()
+  def validate_account_id({field, account_id}) do
+    case AccountID.new(account_id) do
+      %AccountID{} = account_id -> {:ok, account_id}
+      {:error, reason} -> {:error, [{field, reason}]}
+    end
+  end
+
+  @spec validate_account(component :: component()) :: validation()
+  def validate_account({field, account}) do
+    case Account.new(account) do
+      %Account{} = account -> {:ok, account}
+      {:error, reason} -> {:error, [{field, reason}]}
+    end
+  end
+
+  @spec validate_amount(component :: component()) :: validation()
+  def validate_amount({field, amount}) do
+    case Amount.new(amount) do
+      %Amount{} = amount -> {:ok, amount}
+      {:error, reason} -> {:error, [{field, reason}]}
+    end
+  end
+end

--- a/lib/tx_build/op_validate.ex
+++ b/lib/tx_build/op_validate.ex
@@ -5,7 +5,7 @@ defmodule Stellar.TxBuild.OpValidate do
   alias Stellar.TxBuild.{Account, AccountID, Amount}
 
   @type account_id :: String.t()
-  @type value :: account_id() | asset() | number()
+  @type value :: account_id() | number()
   @type component :: {atom(), value()}
   @type validation :: {:ok, any()} | {:error, atom()}
 

--- a/test/tx_build/create_account_test.exs
+++ b/test/tx_build/create_account_test.exs
@@ -29,13 +29,17 @@ defmodule Stellar.TxBuild.CreateAccountTest do
   end
 
   test "new/2 with_invalid_destination", %{amount: amount} do
-    {:error, :invalid_destination} =
+    {:error, [destination: :invalid_account_id]} =
       CreateAccount.new(destination: "ABC", starting_balance: amount)
   end
 
   test "new/2 with_invalid_amount", %{public_key: public_key} do
-    {:error, :invalid_starting_balance} =
+    {:error, [starting_balance: :invalid_amount]} =
       CreateAccount.new(destination: public_key, starting_balance: "123")
+  end
+
+  test "new/2 with_invalid_attributes", %{public_key: public_key} do
+    {:error, :invalid_operation_attributes} = CreateAccount.new(public_key, "123")
   end
 
   test "to_xdr/1", %{xdr: xdr, public_key: public_key, amount: amount} do

--- a/test/tx_build/op_validate_test.exs
+++ b/test/tx_build/op_validate_test.exs
@@ -1,0 +1,33 @@
+defmodule Stellar.TxBuild.OpValidateTest do
+  use ExUnit.Case
+
+  alias Stellar.TxBuild.{Account, AccountID, Amount, OpValidate}
+
+  setup do
+    %{account_id: "GD726E62G6G4ANHWHIQTH5LNMFVF2EQSEXITB6DZCCTKVU6EQRRE2SJS"}
+  end
+
+  test "validate_account_id/2", %{account_id: account_id} do
+    {:ok, %AccountID{}} = OpValidate.validate_account_id({:destination, account_id})
+  end
+
+  test "validate_account_id/2 error" do
+    {:error, [destination: :invalid_account_id]} = OpValidate.validate_account_id({:destination, "ABC"})
+  end
+
+  test "validate_account/2", %{account_id: account_id} do
+    {:ok, %Account{}} = OpValidate.validate_account({:destination, account_id})
+  end
+
+  test "validate_account/2 error" do
+    {:error, [destination: :invalid_account_id]} = OpValidate.validate_account_id({:destination, "ABC"})
+  end
+
+  test "validate_amount/2" do
+    {:ok, %Amount{}} = OpValidate.validate_amount({:starting_balance, 100})
+  end
+
+  test "validate_amount/2 error" do
+    {:error, [starting_balance: :invalid_amount]} = OpValidate.validate_amount({:starting_balance, "100"})
+  end
+end

--- a/test/tx_build/op_validate_test.exs
+++ b/test/tx_build/op_validate_test.exs
@@ -12,7 +12,8 @@ defmodule Stellar.TxBuild.OpValidateTest do
   end
 
   test "validate_account_id/2 error" do
-    {:error, [destination: :invalid_account_id]} = OpValidate.validate_account_id({:destination, "ABC"})
+    {:error, [destination: :invalid_account_id]} =
+      OpValidate.validate_account_id({:destination, "ABC"})
   end
 
   test "validate_account/2", %{account_id: account_id} do
@@ -20,7 +21,8 @@ defmodule Stellar.TxBuild.OpValidateTest do
   end
 
   test "validate_account/2 error" do
-    {:error, [destination: :invalid_account_id]} = OpValidate.validate_account_id({:destination, "ABC"})
+    {:error, [destination: :invalid_account_id]} =
+      OpValidate.validate_account_id({:destination, "ABC"})
   end
 
   test "validate_amount/2" do
@@ -28,6 +30,7 @@ defmodule Stellar.TxBuild.OpValidateTest do
   end
 
   test "validate_amount/2 error" do
-    {:error, [starting_balance: :invalid_amount]} = OpValidate.validate_amount({:starting_balance, "100"})
+    {:error, [starting_balance: :invalid_amount]} =
+      OpValidate.validate_amount({:starting_balance, "100"})
   end
 end


### PR DESCRIPTION
This is part of #41 

While implementing the #30 we noticed there are common operation components that will require the same validation process. 

This PR abstracts validation functions making them reusable to any operation 