### PR TITLE
Ops validations refactor

### DIFF
--- a/lib/tx_build/account.ex
+++ b/lib/tx_build/account.ex
@@ -7,20 +7,19 @@ defmodule Stellar.TxBuild.Account do
 
   @behaviour Stellar.TxBuild.XDR
 
-  @type validation :: {:ok, any()} | {:error, atom()}
+  @type account_id :: String.t()
+  @type validation :: {:ok, account_id()} | {:error, atom()}
 
-  @type id :: integer() | nil
+  @type t :: %__MODULE__{account_id: account_id()}
 
-  @type t :: %__MODULE__{account_id: String.t(), id: id()}
-
-  defstruct [:account_id, :id]
+  defstruct [:account_id]
 
   @impl true
-  def new(account_id, id \\ nil)
+  def new(account_id, opts \\ [])
 
-  def new(account_id, id) do
-    with {:ok, account_id} <- validate_account_id(account_id),
-         do: %__MODULE__{account_id: account_id, id: id}
+  def new(account_id, _opts) do
+    with {:ok, account_id} <- validate_raw_account_id(account_id),
+         do: %__MODULE__{account_id: account_id}
   end
 
   @impl true
@@ -33,8 +32,8 @@ defmodule Stellar.TxBuild.Account do
     |> MuxedAccount.new(type)
   end
 
-  @spec validate_account_id(account_id :: String.t()) :: validation()
-  defp validate_account_id(account_id) do
+  @spec validate_raw_account_id(account_id :: account_id()) :: validation()
+  defp validate_raw_account_id(account_id) do
     case KeyPair.validate_ed25519_public_key(account_id) do
       :ok -> {:ok, account_id}
       _error -> {:error, :invalid_account_id}

--- a/lib/tx_build/account_id.ex
+++ b/lib/tx_build/account_id.ex
@@ -7,9 +7,10 @@ defmodule Stellar.TxBuild.AccountID do
 
   @behaviour Stellar.TxBuild.XDR
 
-  @type validation :: {:ok, any()} | {:error, atom()}
+  @type account_id :: String.t()
+  @type validation :: {:ok, account_id()} | {:error, atom()}
 
-  @type t :: %__MODULE__{account_id: String.t()}
+  @type t :: %__MODULE__{account_id: account_id()}
 
   defstruct [:account_id]
 
@@ -17,7 +18,7 @@ defmodule Stellar.TxBuild.AccountID do
   def new(account_id, opts \\ [])
 
   def new(account_id, _opts) do
-    with {:ok, account_id} <- validate_account_id(account_id),
+    with {:ok, account_id} <- validate_raw_account_id(account_id),
          do: %__MODULE__{account_id: account_id}
   end
 
@@ -32,8 +33,8 @@ defmodule Stellar.TxBuild.AccountID do
     |> AccountID.new()
   end
 
-  @spec validate_account_id(account_id :: String.t()) :: validation()
-  defp validate_account_id(account_id) do
+  @spec validate_raw_account_id(account_id :: account_id()) :: validation()
+  defp validate_raw_account_id(account_id) do
     case KeyPair.validate_ed25519_public_key(account_id) do
       :ok -> {:ok, account_id}
       _error -> {:error, :invalid_account_id}

--- a/lib/tx_build/account_merge.ex
+++ b/lib/tx_build/account_merge.ex
@@ -1,8 +1,9 @@
 defmodule Stellar.TxBuild.AccountMerge do
   @moduledoc """
-  Transfers the native balance (the amount of XLM an account holds) to another account and removes the source account from the ledger.
+  Transfers the native balance (the amount of XLM an account holds) to another
+  account and removes the source account from the ledger.
   """
-  import Stellar.TxBuild.OpValidate
+  import Stellar.TxBuild.Validations, only: [validate_account: 1, validate_optional_account: 1]
 
   alias Stellar.TxBuild.{Account, OptionalAccount}
   alias StellarBase.XDR.{OperationBody, OperationType, Operations.AccountMerge}

--- a/lib/tx_build/begin_sponsoring_future_reserves.ex
+++ b/lib/tx_build/begin_sponsoring_future_reserves.ex
@@ -3,7 +3,7 @@ defmodule Stellar.TxBuild.BeginSponsoringFutureReserves do
   Initiates a sponsorship.
   There must be a corresponding EndSponsoringFutureReserves operation in the same transaction.
   """
-  import Stellar.TxBuild.OpValidate
+  import Stellar.TxBuild.Validations, only: [validate_account_id: 1, validate_optional_account: 1]
 
   alias Stellar.TxBuild.{AccountID, OptionalAccount}
   alias StellarBase.XDR.{OperationBody, OperationType, Operations.BeginSponsoringFutureReserves}

--- a/lib/tx_build/bump_sequence.ex
+++ b/lib/tx_build/bump_sequence.ex
@@ -2,7 +2,8 @@ defmodule Stellar.TxBuild.BumpSequence do
   @moduledoc """
   Bumps sequence number.
   """
-  import Stellar.TxBuild.OpValidate
+  import Stellar.TxBuild.Validations,
+    only: [validate_pos_integer: 1, validate_optional_account: 1]
 
   alias Stellar.TxBuild.OptionalAccount
   alias StellarBase.XDR.{OperationBody, OperationType, Operations.BumpSequence, SequenceNumber}

--- a/lib/tx_build/change_trust.ex
+++ b/lib/tx_build/change_trust.ex
@@ -2,7 +2,7 @@ defmodule Stellar.TxBuild.ChangeTrust do
   @moduledoc """
   Creates, updates, or deletes a trustline.
   """
-  import Stellar.TxBuild.OpValidate,
+  import Stellar.TxBuild.Validations,
     only: [validate_asset: 1, validate_optional_account: 1, validate_optional_amount: 1]
 
   alias Stellar.TxBuild.{Amount, Asset, OptionalAccount}

--- a/lib/tx_build/clawback.ex
+++ b/lib/tx_build/clawback.ex
@@ -2,7 +2,13 @@ defmodule Stellar.TxBuild.Clawback do
   @moduledoc """
   Creates a clawback operation.
   """
-  import Stellar.TxBuild.OpValidate
+  import Stellar.TxBuild.Validations,
+    only: [
+      validate_account: 1,
+      validate_asset: 1,
+      validate_amount: 1,
+      validate_optional_account: 1
+    ]
 
   alias Stellar.TxBuild.{Account, Amount, Asset, OptionalAccount}
   alias StellarBase.XDR.{OperationBody, OperationType, Operations.Clawback}

--- a/lib/tx_build/clawback_claimable_balance.ex
+++ b/lib/tx_build/clawback_claimable_balance.ex
@@ -2,7 +2,8 @@ defmodule Stellar.TxBuild.ClawbackClaimableBalance do
   @moduledoc """
   Creates a clawback operation for a claimable balance.
   """
-  import Stellar.TxBuild.OpValidate
+  import Stellar.TxBuild.Validations,
+    only: [validate_claimable_balance_id: 1, validate_optional_account: 1]
 
   alias Stellar.TxBuild.{ClaimableBalanceID, OptionalAccount}
   alias StellarBase.XDR.{OperationBody, OperationType, Operations.ClawbackClaimableBalance}

--- a/lib/tx_build/create_account.ex
+++ b/lib/tx_build/create_account.ex
@@ -2,7 +2,8 @@ defmodule Stellar.TxBuild.CreateAccount do
   @moduledoc """
   Creates and funds a new account with the specified starting balance.
   """
-  import Stellar.TxBuild.OpValidate
+  import Stellar.TxBuild.Validations,
+    only: [validate_account_id: 1, validate_amount: 1, validate_optional_account: 1]
 
   alias Stellar.TxBuild.{AccountID, Amount, OptionalAccount}
   alias StellarBase.XDR.{OperationBody, OperationType, Operations.CreateAccount}

--- a/lib/tx_build/create_passive_sell_offer.ex
+++ b/lib/tx_build/create_passive_sell_offer.ex
@@ -2,7 +2,8 @@ defmodule Stellar.TxBuild.CreatePassiveSellOffer do
   @moduledoc """
   Creates an offer that does not take another offer of equal price when created.
   """
-  import Stellar.TxBuild.OpValidate
+  import Stellar.TxBuild.Validations,
+    only: [validate_asset: 1, validate_amount: 1, validate_price: 1, validate_optional_account: 1]
 
   alias Stellar.TxBuild.{Amount, Asset, OptionalAccount, Price}
   alias StellarBase.XDR.{OperationBody, OperationType, Operations.CreatePassiveSellOffer}

--- a/lib/tx_build/end_sponsoring_future_reserves.ex
+++ b/lib/tx_build/end_sponsoring_future_reserves.ex
@@ -2,7 +2,7 @@ defmodule Stellar.TxBuild.EndSponsoringFutureReserves do
   @moduledoc """
   Ends a sponsorship.
   """
-  import Stellar.TxBuild.OpValidate
+  import Stellar.TxBuild.Validations, only: [validate_optional_account: 1]
 
   alias Stellar.TxBuild.OptionalAccount
   alias StellarBase.XDR.{OperationBody, OperationType, Void}

--- a/lib/tx_build/manage_buy_offer.ex
+++ b/lib/tx_build/manage_buy_offer.ex
@@ -2,7 +2,14 @@ defmodule Stellar.TxBuild.ManageBuyOffer do
   @moduledoc """
   Creates, updates, or deletes an offer.
   """
-  import Stellar.TxBuild.OpValidate
+  import Stellar.TxBuild.Validations,
+    only: [
+      validate_asset: 1,
+      validate_pos_integer: 1,
+      validate_amount: 1,
+      validate_price: 1,
+      validate_optional_account: 1
+    ]
 
   alias Stellar.TxBuild.{Amount, Asset, OptionalAccount, Price}
   alias StellarBase.XDR.{OperationBody, OperationType, Operations.ManageBuyOffer, Int64}

--- a/lib/tx_build/manage_data.ex
+++ b/lib/tx_build/manage_data.ex
@@ -2,7 +2,7 @@ defmodule Stellar.TxBuild.ManageData do
   @moduledoc """
   Sets, modifies, or deletes a Data Entry (name/value pair).
   """
-  import Stellar.TxBuild.OpValidate
+  import Stellar.TxBuild.Validations, only: [validate_optional_account: 1]
 
   alias Stellar.TxBuild.OptionalAccount
 

--- a/lib/tx_build/manage_sell_offer.ex
+++ b/lib/tx_build/manage_sell_offer.ex
@@ -2,7 +2,14 @@ defmodule Stellar.TxBuild.ManageSellOffer do
   @moduledoc """
   Creates, updates, or deletes an offer.
   """
-  import Stellar.TxBuild.OpValidate
+  import Stellar.TxBuild.Validations,
+    only: [
+      validate_asset: 1,
+      validate_pos_integer: 1,
+      validate_amount: 1,
+      validate_price: 1,
+      validate_optional_account: 1
+    ]
 
   alias Stellar.TxBuild.{Amount, Asset, OptionalAccount, Price}
   alias StellarBase.XDR.{OperationBody, OperationType, Operations.ManageSellOffer, Int64}

--- a/lib/tx_build/memo.ex
+++ b/lib/tx_build/memo.ex
@@ -15,26 +15,26 @@ defmodule Stellar.TxBuild.Memo do
   defstruct [:type, :value]
 
   @impl true
-  def new(type \\ :none, value \\ nil)
-
-  def new(:text, value) when is_bitstring(value) and byte_size(value) < 28 do
-    %__MODULE__{type: :MEMO_TEXT, value: value}
-  end
-
-  def new(:id, value) when is_integer(value) do
-    %__MODULE__{type: :MEMO_ID, value: value}
-  end
-
-  def new(:hash, value) when is_binary(value) do
-    %__MODULE__{type: :MEMO_HASH, value: value}
-  end
-
-  def new(:return, value) when is_binary(value) do
-    %__MODULE__{type: :MEMO_RETURN, value: value}
-  end
+  def new(type \\ :none, opts \\ [])
 
   def new(:none, _value) do
     %__MODULE__{type: :MEMO_NONE, value: nil}
+  end
+
+  def new([text: value], _opts) when is_bitstring(value) and byte_size(value) < 28 do
+    %__MODULE__{type: :MEMO_TEXT, value: value}
+  end
+
+  def new([id: value], _opts) when is_integer(value) do
+    %__MODULE__{type: :MEMO_ID, value: value}
+  end
+
+  def new([hash: value], _opts) when is_bitstring(value) and byte_size(value) == 64 do
+    %__MODULE__{type: :MEMO_HASH, value: value}
+  end
+
+  def new([return: value], _opts) when is_bitstring(value) and byte_size(value) == 64 do
+    %__MODULE__{type: :MEMO_RETURN, value: value}
   end
 
   def new(_type, _value), do: {:error, :invalid_memo}
@@ -49,9 +49,14 @@ defmodule Stellar.TxBuild.Memo do
   end
 
   @spec memo_xdr_value(value :: memo_value(), type :: atom()) :: xdr_memo_value()
+  defp memo_xdr_value(value, memo_type) when memo_type in [:MEMO_HASH, :MEMO_RETURN] do
+    value
+    |> String.upcase()
+    |> Base.decode16!()
+    |> Hash.new()
+  end
+
   defp memo_xdr_value(_value, :MEMO_NONE), do: nil
   defp memo_xdr_value(value, :MEMO_TEXT), do: String28.new(value)
   defp memo_xdr_value(value, :MEMO_ID), do: UInt64.new(value)
-  defp memo_xdr_value(value, :MEMO_HASH), do: Hash.new(value)
-  defp memo_xdr_value(value, :MEMO_RETURN), do: Hash.new(value)
 end

--- a/lib/tx_build/path_payment_strict_receive.ex
+++ b/lib/tx_build/path_payment_strict_receive.ex
@@ -2,7 +2,14 @@ defmodule Stellar.TxBuild.PathPaymentStrictReceive do
   @moduledoc """
   Sends an amount in a specific asset to a destination account through a path of offers.
   """
-  import Stellar.TxBuild.OpValidate
+  import Stellar.TxBuild.Validations,
+    only: [
+      validate_account: 1,
+      validate_asset: 1,
+      validate_optional_assets_path: 1,
+      validate_amount: 1,
+      validate_optional_account: 1
+    ]
 
   alias Stellar.TxBuild.{Account, Amount, Asset, AssetsPath, OptionalAccount}
   alias StellarBase.XDR.{OperationBody, OperationType, Operations.PathPaymentStrictReceive}

--- a/lib/tx_build/path_payment_strict_send.ex
+++ b/lib/tx_build/path_payment_strict_send.ex
@@ -2,7 +2,14 @@ defmodule Stellar.TxBuild.PathPaymentStrictSend do
   @moduledoc """
   Sends an amount in a specific asset to a destination account through a path of offers.
   """
-  import Stellar.TxBuild.OpValidate
+  import Stellar.TxBuild.Validations,
+    only: [
+      validate_account: 1,
+      validate_asset: 1,
+      validate_optional_assets_path: 1,
+      validate_amount: 1,
+      validate_optional_account: 1
+    ]
 
   alias Stellar.TxBuild.{Account, Amount, Asset, AssetsPath, OptionalAccount}
   alias StellarBase.XDR.{OperationBody, OperationType, Operations.PathPaymentStrictSend}

--- a/lib/tx_build/payment.ex
+++ b/lib/tx_build/payment.ex
@@ -2,16 +2,18 @@ defmodule Stellar.TxBuild.Payment do
   @moduledoc """
   Sends an amount in a specific asset to a destination account.
   """
-  import Stellar.TxBuild.OpValidate
+  import Stellar.TxBuild.Validations,
+    only: [
+      validate_account: 1,
+      validate_asset: 1,
+      validate_amount: 1,
+      validate_optional_account: 1
+    ]
 
   alias Stellar.TxBuild.{Account, Amount, Asset, OptionalAccount}
   alias StellarBase.XDR.{OperationBody, OperationType, Operations.Payment}
 
   @behaviour Stellar.TxBuild.XDR
-
-  @type asset_issuer :: String.t()
-  @type asset_code :: String.t()
-  @type asset :: {asset_code(), asset_issuer()} | Keyword.t() | atom()
 
   @type t :: %__MODULE__{
           destination: Account.t(),

--- a/lib/tx_build/set_options.ex
+++ b/lib/tx_build/set_options.ex
@@ -3,20 +3,23 @@ defmodule Stellar.TxBuild.SetOptions do
   Sets various configuration options for an account.
   """
   import Stellar.TxBuild.Validations,
-    only: [validate_optional_account: 1, validate_optional_account_id: 1]
+    only: [
+      validate_optional_account: 1,
+      validate_optional_account_id: 1,
+      validate_optional_flags: 1,
+      validate_optional_weight: 1,
+      validate_optional_string32: 1,
+      validate_optional_signer: 1
+    ]
 
   alias Stellar.TxBuild.{
-    Flags,
     OptionalAccount,
     OptionalAccountID,
     OptionalFlags,
     OptionalString32,
     OptionalSigner,
     OptionalString32,
-    OptionalWeight,
-    Signer,
-    String32,
-    Weight
+    OptionalWeight
   }
 
   alias StellarBase.XDR.{OperationBody, OperationType, Operations.SetOptions}
@@ -131,45 +134,5 @@ defmodule Stellar.TxBuild.SetOptions do
       )
 
     OperationBody.new(set_options, op_type)
-  end
-
-  @spec validate_optional_flags(component :: component()) :: validation()
-  defp validate_optional_flags({_field, nil}), do: {:ok, OptionalFlags.new()}
-
-  defp validate_optional_flags({field, value}) do
-    case Flags.new(value) do
-      %Flags{} = flags -> {:ok, OptionalFlags.new(flags)}
-      {:error, reason} -> {:error, [{field, reason}]}
-    end
-  end
-
-  @spec validate_optional_weight(component :: component()) :: validation()
-  defp validate_optional_weight({_field, nil}), do: {:ok, OptionalWeight.new()}
-
-  defp validate_optional_weight({field, value}) do
-    case Weight.new(value) do
-      %Weight{} = weight -> {:ok, OptionalWeight.new(weight)}
-      {:error, reason} -> {:error, [{field, reason}]}
-    end
-  end
-
-  @spec validate_optional_string32(component :: component()) :: validation()
-  defp validate_optional_string32({_field, nil}), do: {:ok, OptionalString32.new()}
-
-  defp validate_optional_string32({field, value}) do
-    case String32.new(value) do
-      %String32{} = str -> {:ok, OptionalString32.new(str)}
-      {:error, reason} -> {:error, [{field, reason}]}
-    end
-  end
-
-  @spec validate_optional_signer(component :: component()) :: validation()
-  defp validate_optional_signer({_field, nil}), do: {:ok, OptionalSigner.new()}
-
-  defp validate_optional_signer({field, value}) do
-    case Signer.new(value) do
-      %Signer{} = signer -> {:ok, OptionalSigner.new(signer)}
-      {:error, reason} -> {:error, [{field, reason}]}
-    end
   end
 end

--- a/lib/tx_build/set_options.ex
+++ b/lib/tx_build/set_options.ex
@@ -2,9 +2,11 @@ defmodule Stellar.TxBuild.SetOptions do
   @moduledoc """
   Sets various configuration options for an account.
   """
+  import Stellar.TxBuild.Validations,
+    only: [validate_optional_account: 1, validate_optional_account_id: 1]
+
   alias Stellar.TxBuild.{
     Flags,
-    OpValidate,
     OptionalAccount,
     OptionalAccountID,
     OptionalFlags,
@@ -65,16 +67,16 @@ defmodule Stellar.TxBuild.SetOptions do
     signer = Keyword.get(args, :signer)
     source_account = Keyword.get(args, :source_account)
 
-    with {:ok, inf_dest} <- validate(:account_id, {:inflation_destination, inf_dest}),
-         {:ok, clear_flags} <- validate(:flags, {:clear_flags, clear_flags}),
-         {:ok, set_flags} <- validate(:flags, {:set_flags, set_flags}),
-         {:ok, master_weight} <- validate(:weight, {:master_weight, master_weight}),
-         {:ok, low_threshold} <- validate(:weight, {:low_threshold, low_threshold}),
-         {:ok, med_threshold} <- validate(:weight, {:medium_threshold, med_threshold}),
-         {:ok, high_threshold} <- validate(:weight, {:high_threshold, high_threshold}),
-         {:ok, home_domain} <- validate(:string32, {:home_domain, home_domain}),
-         {:ok, signer} <- validate(:signer, {:signer, signer}),
-         {:ok, source_account} <- validate(:account, {:source_account, source_account}) do
+    with {:ok, inf_dest} <- validate_optional_account_id({:inflation_destination, inf_dest}),
+         {:ok, clear_flags} <- validate_optional_flags({:clear_flags, clear_flags}),
+         {:ok, set_flags} <- validate_optional_flags({:set_flags, set_flags}),
+         {:ok, master_weight} <- validate_optional_weight({:master_weight, master_weight}),
+         {:ok, low_threshold} <- validate_optional_weight({:low_threshold, low_threshold}),
+         {:ok, med_threshold} <- validate_optional_weight({:medium_threshold, med_threshold}),
+         {:ok, high_threshold} <- validate_optional_weight({:high_threshold, high_threshold}),
+         {:ok, home_domain} <- validate_optional_string32({:home_domain, home_domain}),
+         {:ok, signer} <- validate_optional_signer({:signer, signer}),
+         {:ok, source_account} <- validate_optional_account({:source_account, source_account}) do
       %__MODULE__{
         inflation_destination: inf_dest,
         clear_flags: clear_flags,
@@ -131,45 +133,40 @@ defmodule Stellar.TxBuild.SetOptions do
     OperationBody.new(set_options, op_type)
   end
 
-  @spec validate(type :: atom(), component :: component()) :: validation()
-  defp validate(:account_id, component) do
-    OpValidate.validate_optional_account_id(component)
-  end
+  @spec validate_optional_flags(component :: component()) :: validation()
+  defp validate_optional_flags({_field, nil}), do: {:ok, OptionalFlags.new()}
 
-  defp validate(:account, component) do
-    OpValidate.validate_optional_account(component)
-  end
-
-  defp validate(:flags, {_field, nil}), do: {:ok, OptionalFlags.new()}
-
-  defp validate(:flags, {field, value}) do
+  defp validate_optional_flags({field, value}) do
     case Flags.new(value) do
       %Flags{} = flags -> {:ok, OptionalFlags.new(flags)}
       {:error, reason} -> {:error, [{field, reason}]}
     end
   end
 
-  defp validate(:weight, {_field, nil}), do: {:ok, OptionalWeight.new()}
+  @spec validate_optional_weight(component :: component()) :: validation()
+  defp validate_optional_weight({_field, nil}), do: {:ok, OptionalWeight.new()}
 
-  defp validate(:weight, {field, value}) do
+  defp validate_optional_weight({field, value}) do
     case Weight.new(value) do
       %Weight{} = weight -> {:ok, OptionalWeight.new(weight)}
       {:error, reason} -> {:error, [{field, reason}]}
     end
   end
 
-  defp validate(:string32, {_field, nil}), do: {:ok, OptionalString32.new()}
+  @spec validate_optional_string32(component :: component()) :: validation()
+  defp validate_optional_string32({_field, nil}), do: {:ok, OptionalString32.new()}
 
-  defp validate(:string32, {field, value}) do
+  defp validate_optional_string32({field, value}) do
     case String32.new(value) do
       %String32{} = str -> {:ok, OptionalString32.new(str)}
       {:error, reason} -> {:error, [{field, reason}]}
     end
   end
 
-  defp validate(:signer, {_field, nil}), do: {:ok, OptionalSigner.new()}
+  @spec validate_optional_signer(component :: component()) :: validation()
+  defp validate_optional_signer({_field, nil}), do: {:ok, OptionalSigner.new()}
 
-  defp validate(:signer, {field, value}) do
+  defp validate_optional_signer({field, value}) do
     case Signer.new(value) do
       %Signer{} = signer -> {:ok, OptionalSigner.new(signer)}
       {:error, reason} -> {:error, [{field, reason}]}

--- a/lib/tx_build/signature.ex
+++ b/lib/tx_build/signature.ex
@@ -26,7 +26,9 @@ defmodule Stellar.TxBuild.Signature do
   defstruct [:public_key, :secret, :raw_public_key, :raw_secret, :hint]
 
   @impl true
-  def new(public_key, secret) do
+  def new(keypair, opts \\ [])
+
+  def new({public_key, secret}, _opts) do
     with :ok <- KeyPair.validate_ed25519_public_key(public_key),
          :ok <- KeyPair.validate_ed25519_secret_seed(secret),
          do: build_signature(public_key, secret)

--- a/lib/tx_build/signer.ex
+++ b/lib/tx_build/signer.ex
@@ -24,9 +24,9 @@ defmodule Stellar.TxBuild.Signer do
   def new(args, opts \\ [])
 
   def new([{type, key}, {:weight, weight}], _opts) do
-    with {:ok, type} <- validate_type(type),
-         {:ok, key} <- validate_key({type, key}),
-         {:ok, weight} <- validate_weight(weight) do
+    with {:ok, type} <- validate_signer_type(type),
+         {:ok, key} <- validate_signer_key({type, key}),
+         {:ok, weight} <- validate_signer_weight(weight) do
       %__MODULE__{type: type, key: key, weight: weight}
     end
   end
@@ -67,29 +67,29 @@ defmodule Stellar.TxBuild.Signer do
     |> Signer.new(weight)
   end
 
-  @spec validate_type(type :: signer_type()) :: validation()
-  defp validate_type(type) when type in @signer_types, do: {:ok, type}
-  defp validate_type(_type), do: {:error, :invalid_signer_type}
+  @spec validate_signer_type(type :: signer_type()) :: validation()
+  defp validate_signer_type(type) when type in @signer_types, do: {:ok, type}
+  defp validate_signer_type(_type), do: {:error, :invalid_signer_type}
 
-  @spec validate_weight(weight :: non_neg_integer()) :: validation()
-  defp validate_weight(weight) do
+  @spec validate_signer_weight(weight :: non_neg_integer()) :: validation()
+  defp validate_signer_weight(weight) do
     case Weight.new(weight) do
       %Weight{} = weight -> {:ok, weight}
       {:error, _reason} -> {:error, :invalid_signer_weight}
     end
   end
 
-  @spec validate_key(signer :: signer()) :: validation()
-  defp validate_key({:ed25519, key}) do
+  @spec validate_signer_key(signer :: signer()) :: validation()
+  defp validate_signer_key({:ed25519, key}) do
     case KeyPair.validate_ed25519_public_key(key) do
       :ok -> {:ok, key}
       _error -> {:error, :invalid_signer_key}
     end
   end
 
-  defp validate_key({type, key})
+  defp validate_signer_key({type, key})
        when type in [:sha256_hash, :pre_auth_tx] and byte_size(key) == 64,
        do: {:ok, key}
 
-  defp validate_key(_type), do: {:error, :invalid_signer_key}
+  defp validate_signer_key(_type), do: {:error, :invalid_signer_key}
 end

--- a/lib/tx_build/validations.ex
+++ b/lib/tx_build/validations.ex
@@ -1,6 +1,6 @@
 defmodule Stellar.TxBuild.Validations do
   @moduledoc """
-  Validates operation components.
+  Ensures that child components/structures used by operations are properly initialized otherwise, returns a formatted error.
   """
   alias Stellar.TxBuild.{
     Account,
@@ -8,10 +8,18 @@ defmodule Stellar.TxBuild.Validations do
     Amount,
     Asset,
     AssetsPath,
+    Flags,
     ClaimableBalanceID,
     OptionalAccount,
     OptionalAccountID,
-    Price
+    OptionalFlags,
+    OptionalWeight,
+    OptionalSigner,
+    OptionalString32,
+    Price,
+    Signer,
+    String32,
+    Weight
   }
 
   @type account_id :: String.t()
@@ -107,6 +115,46 @@ defmodule Stellar.TxBuild.Validations do
   def validate_claimable_balance_id({field, balance_id}) do
     case ClaimableBalanceID.new(balance_id) do
       %ClaimableBalanceID{} = claimable_balance_id -> {:ok, claimable_balance_id}
+      {:error, reason} -> {:error, [{field, reason}]}
+    end
+  end
+
+  @spec validate_optional_flags(component :: component()) :: validation()
+  def validate_optional_flags({_field, nil}), do: {:ok, OptionalFlags.new()}
+
+  def validate_optional_flags({field, value}) do
+    case Flags.new(value) do
+      %Flags{} = flags -> {:ok, OptionalFlags.new(flags)}
+      {:error, reason} -> {:error, [{field, reason}]}
+    end
+  end
+
+  @spec validate_optional_weight(component :: component()) :: validation()
+  def validate_optional_weight({_field, nil}), do: {:ok, OptionalWeight.new()}
+
+  def validate_optional_weight({field, value}) do
+    case Weight.new(value) do
+      %Weight{} = weight -> {:ok, OptionalWeight.new(weight)}
+      {:error, reason} -> {:error, [{field, reason}]}
+    end
+  end
+
+  @spec validate_optional_string32(component :: component()) :: validation()
+  def validate_optional_string32({_field, nil}), do: {:ok, OptionalString32.new()}
+
+  def validate_optional_string32({field, value}) do
+    case String32.new(value) do
+      %String32{} = str -> {:ok, OptionalString32.new(str)}
+      {:error, reason} -> {:error, [{field, reason}]}
+    end
+  end
+
+  @spec validate_optional_signer(component :: component()) :: validation()
+  def validate_optional_signer({_field, nil}), do: {:ok, OptionalSigner.new()}
+
+  def validate_optional_signer({field, value}) do
+    case Signer.new(value) do
+      %Signer{} = signer -> {:ok, OptionalSigner.new(signer)}
       {:error, reason} -> {:error, [{field, reason}]}
     end
   end

--- a/lib/tx_build/validations.ex
+++ b/lib/tx_build/validations.ex
@@ -1,4 +1,4 @@
-defmodule Stellar.TxBuild.OpValidate do
+defmodule Stellar.TxBuild.Validations do
   @moduledoc """
   Validates operation components.
   """
@@ -15,7 +15,8 @@ defmodule Stellar.TxBuild.OpValidate do
   }
 
   @type account_id :: String.t()
-  @type asset :: {String.t(), account_id()} | Keyword.t() | atom()
+  @type asset_code :: String.t()
+  @type asset :: {asset_code(), account_id()} | Keyword.t() | atom()
   @type value :: account_id() | asset() | number()
   @type component :: {atom(), value()}
   @type error :: Keyword.t() | atom()

--- a/test/support/xdr_fixtures.ex
+++ b/test/support/xdr_fixtures.ex
@@ -619,8 +619,13 @@ defmodule Stellar.Test.XDRFixtures do
   defp memo_xdr_value(_value, :MEMO_NONE), do: nil
   defp memo_xdr_value(value, :MEMO_TEXT), do: String28.new(value)
   defp memo_xdr_value(value, :MEMO_ID), do: UInt64.new(value)
-  defp memo_xdr_value(value, :MEMO_HASH), do: Hash.new(value)
-  defp memo_xdr_value(value, :MEMO_RETURN), do: Hash.new(value)
+
+  defp memo_xdr_value(value, _type) do
+    value
+    |> String.upcase()
+    |> Base.decode16!()
+    |> Hash.new()
+  end
 
   @spec flags_bit_mask(flags :: flags()) :: integer()
   defp flags_bit_mask(nil), do: 0

--- a/test/tx_build/account_test.exs
+++ b/test/tx_build/account_test.exs
@@ -14,7 +14,7 @@ defmodule Stellar.TxBuild.AccountTest do
   end
 
   test "new/2", %{account_id: account_id} do
-    %Account{account_id: ^account_id, id: nil} = Account.new(account_id)
+    %Account{account_id: ^account_id} = Account.new(account_id)
   end
 
   test "new/2 invalid_key" do

--- a/test/tx_build/default_test.exs
+++ b/test/tx_build/default_test.exs
@@ -67,8 +67,8 @@ defmodule Stellar.TxBuild.DefaultTest do
       TxBuild.add_operations(tx_build, [op1, op2])
   end
 
-  test "sign/2", %{keypair: {public_key, secret}, tx_build: tx_build} do
-    signature = Signature.new(public_key, secret)
+  test "sign/2", %{keypair: keypair, tx_build: tx_build} do
+    signature = Signature.new(keypair)
     %TxBuild{signatures: [^signature | _signatures]} = TxBuild.sign(tx_build, signature)
   end
 

--- a/test/tx_build/default_test.exs
+++ b/test/tx_build/default_test.exs
@@ -20,7 +20,7 @@ defmodule Stellar.TxBuild.DefaultTest do
     {public_key, secret} =
       keypair = KeyPair.from_secret("SACHJRYLY43MUXRRCRFA6CZ5ZW5JVPPR4CWYWIX6BWRAOHOFVPVYDO5Z")
 
-    signature = Signature.new(public_key, secret)
+    signature = Signature.new({public_key, secret})
     account = Account.new("GD726E62G6G4ANHWHIQTH5LNMFVF2EQSEXITB6DZCCTKVU6EQRRE2SJS")
     tx = Transaction.new(account)
 
@@ -41,7 +41,7 @@ defmodule Stellar.TxBuild.DefaultTest do
   end
 
   test "add_memo/2", %{tx_build: tx_build} do
-    memo = Memo.new(:text, "hello")
+    memo = Memo.new(text: "hello")
     %TxBuild{tx: %Transaction{memo: ^memo}} = TxBuild.add_memo(tx_build, memo)
   end
 
@@ -74,7 +74,7 @@ defmodule Stellar.TxBuild.DefaultTest do
 
   test "sign/2 multiple", %{signature: signature, tx_build: tx_build} do
     {pk, sk} = KeyPair.random()
-    signatures = [signature, Signature.new(pk, sk)]
+    signatures = [signature, Signature.new({pk, sk})]
 
     %TxBuild{signatures: ^signatures} = TxBuild.sign(tx_build, signatures)
   end

--- a/test/tx_build/memo_test.exs
+++ b/test/tx_build/memo_test.exs
@@ -10,23 +10,29 @@ defmodule Stellar.TxBuild.MemoTest do
     end
 
     test "memo_none" do
-      %Memo{type: :MEMO_NONE, value: nil} = Memo.new(:none, nil)
+      %Memo{type: :MEMO_NONE, value: nil} = Memo.new(:none)
     end
 
     test "memo_text" do
-      %Memo{type: :MEMO_TEXT, value: "hello"} = Memo.new(:text, "hello")
+      %Memo{type: :MEMO_TEXT, value: "hello"} = Memo.new(text: "hello")
     end
 
     test "memo_id" do
-      %Memo{type: :MEMO_ID, value: 123} = Memo.new(:id, 123)
+      %Memo{type: :MEMO_ID, value: 123} = Memo.new(id: 123)
     end
 
     test "memo_hash" do
-      %Memo{type: :MEMO_HASH, value: <<0, 0, 0, 0>>} = Memo.new(:hash, <<0, 0, 0, 0>>)
+      %Memo{
+        type: :MEMO_HASH,
+        value: "0859239b58d3f32972fc9124559cea7251225f2dbc6f0d83f67dc041e6608510"
+      } = Memo.new(hash: "0859239b58d3f32972fc9124559cea7251225f2dbc6f0d83f67dc041e6608510")
     end
 
     test "memo_return" do
-      %Memo{type: :MEMO_RETURN, value: <<0, 0, 0, 0>>} = Memo.new(:return, <<0, 0, 0, 0>>)
+      %Memo{
+        type: :MEMO_RETURN,
+        value: "0859239b58d3f32972fc9124559cea7251225f2dbc6f0d83f67dc041e6608510"
+      } = Memo.new(return: "0859239b58d3f32972fc9124559cea7251225f2dbc6f0d83f67dc041e6608510")
     end
 
     test "invalid_memo" do
@@ -42,26 +48,32 @@ defmodule Stellar.TxBuild.MemoTest do
 
     test "memo_text" do
       memo_text_xdr = memo_xdr(:MEMO_TEXT, "hello")
-      ^memo_text_xdr = Memo.new(:text, "hello") |> Memo.to_xdr()
+      ^memo_text_xdr = Memo.new(text: "hello") |> Memo.to_xdr()
     end
 
     test "memo_id" do
       memo_id_xdr = memo_xdr(:MEMO_ID, 123)
-      ^memo_id_xdr = Memo.new(:id, 123) |> Memo.to_xdr()
+      ^memo_id_xdr = Memo.new(id: 123) |> Memo.to_xdr()
     end
 
     test "memo_hash" do
-      hash = "GCIZ3GSM5XL7OUS4UP64THMDZ7CZ3ZWN"
+      hash = "0859239b58d3f32972fc9124559cea7251225f2dbc6f0d83f67dc041e6608510"
       memo_hash_xdr = memo_xdr(:MEMO_HASH, hash)
 
-      ^memo_hash_xdr = Memo.new(:hash, hash) |> Memo.to_xdr()
+      ^memo_hash_xdr =
+        [hash: hash]
+        |> Memo.new()
+        |> Memo.to_xdr()
     end
 
     test "memo_return" do
-      hash = "GCIZ3GSM5XL7OUS4UP64THMDZ7CZ3ZWN"
-      memo_return_xdr = memo_xdr(:MEMO_RETURN, "GCIZ3GSM5XL7OUS4UP64THMDZ7CZ3ZWN")
+      hash = "0859239b58d3f32972fc9124559cea7251225f2dbc6f0d83f67dc041e6608510"
+      memo_return_xdr = memo_xdr(:MEMO_RETURN, hash)
 
-      ^memo_return_xdr = Memo.new(:return, hash) |> Memo.to_xdr()
+      ^memo_return_xdr =
+        [return: hash]
+        |> Memo.new()
+        |> Memo.to_xdr()
     end
   end
 end

--- a/test/tx_build/signature_test.exs
+++ b/test/tx_build/signature_test.exs
@@ -19,13 +19,13 @@ defmodule Stellar.TxBuild.SignatureTest do
       secret: secret,
       raw_secret: raw_secret,
       hint: hint,
-      signature: Signature.new(public_key, secret)
+      signature: Signature.new({public_key, secret})
     }
   end
 
   test "new/2", %{public_key: public_key, secret: secret, raw_secret: raw_secret, hint: hint} do
     %Signature{public_key: ^public_key, hint: ^hint, raw_secret: ^raw_secret} =
-      Signature.new(public_key, secret)
+      Signature.new({public_key, secret})
   end
 
   test "to_xdr/2", %{signature: signature, secret: raw_secret, hint: hint} do

--- a/test/tx_build/transaction_envelope_test.exs
+++ b/test/tx_build/transaction_envelope_test.exs
@@ -10,7 +10,7 @@ defmodule Stellar.TxBuild.TransactionEnvelopeTest do
     secret = "SACHJRYLY43MUXRRCRFA6CZ5ZW5JVPPR4CWYWIX6BWRAOHOFVPVYDO5Z"
     account = Account.new(public_key)
     tx = Transaction.new(account)
-    signature = Signature.new(public_key, secret)
+    signature = Signature.new({public_key, secret})
     signatures = [signature]
 
     %{

--- a/test/tx_build/transaction_signature_test.exs
+++ b/test/tx_build/transaction_signature_test.exs
@@ -17,7 +17,7 @@ defmodule Stellar.TxBuild.TransactionSignatureTest do
       <<221, 182, 124, 1, 170, 219, 95, 188, 245, 30, 147, 123, 228, 111, 20, 56, 22, 55, 101, 74,
         206, 105, 230, 184, 209, 120, 244, 158, 120, 75, 183, 37>>
 
-    signature = Signature.new(public_key, secret)
+    signature = Signature.new({public_key, secret})
 
     %{
       tx: tx,

--- a/test/tx_build/validations_test.exs
+++ b/test/tx_build/validations_test.exs
@@ -1,4 +1,4 @@
-defmodule Stellar.TxBuild.OpValidateTest do
+defmodule Stellar.TxBuild.ValidationsTest do
   use ExUnit.Case
 
   alias Stellar.TxBuild.{
@@ -8,7 +8,7 @@ defmodule Stellar.TxBuild.OpValidateTest do
     Asset,
     AssetsPath,
     ClaimableBalanceID,
-    OpValidate,
+    Validations,
     OptionalAccountID,
     Price
   }
@@ -21,107 +21,107 @@ defmodule Stellar.TxBuild.OpValidateTest do
   end
 
   test "validate_pos_integer/1" do
-    {:ok, 123} = OpValidate.validate_pos_integer({:offer_id, 123})
+    {:ok, 123} = Validations.validate_pos_integer({:offer_id, 123})
   end
 
   test "validate_pos_integer/1 error" do
-    {:error, [offer_id: :integer_expected]} = OpValidate.validate_pos_integer({:offer_id, "123"})
+    {:error, [offer_id: :integer_expected]} = Validations.validate_pos_integer({:offer_id, "123"})
   end
 
   test "validate_account_id/1", %{account_id: account_id} do
-    {:ok, %AccountID{}} = OpValidate.validate_account_id({:destination, account_id})
+    {:ok, %AccountID{}} = Validations.validate_account_id({:destination, account_id})
   end
 
   test "validate_account_id/1 error" do
     {:error, [destination: :invalid_account_id]} =
-      OpValidate.validate_account_id({:destination, "ABC"})
+      Validations.validate_account_id({:destination, "ABC"})
   end
 
   test "validate_optional_account_id/1", %{account_id: account_id} do
     {:ok, %OptionalAccountID{}} =
-      OpValidate.validate_optional_account_id({:destination, account_id})
+      Validations.validate_optional_account_id({:destination, account_id})
   end
 
   test "validate_optional_account_id/1 none" do
     {:ok, %OptionalAccountID{account_id: nil}} =
-      OpValidate.validate_optional_account_id({:destination, nil})
+      Validations.validate_optional_account_id({:destination, nil})
   end
 
   test "validate_optional_account_id/1 error" do
     {:error, [destination: :invalid_account_id]} =
-      OpValidate.validate_optional_account_id({:destination, "2"})
+      Validations.validate_optional_account_id({:destination, "2"})
   end
 
   test "validate_account/1", %{account_id: account_id} do
-    {:ok, %Account{}} = OpValidate.validate_account({:destination, account_id})
+    {:ok, %Account{}} = Validations.validate_account({:destination, account_id})
   end
 
   test "validate_account/1 error" do
     {:error, [destination: :invalid_account_id]} =
-      OpValidate.validate_account_id({:destination, "ABC"})
+      Validations.validate_account_id({:destination, "ABC"})
   end
 
   test "validate_amount/1" do
-    {:ok, %Amount{}} = OpValidate.validate_amount({:starting_balance, 100})
+    {:ok, %Amount{}} = Validations.validate_amount({:starting_balance, 100})
   end
 
   test "validate_amount/1 error" do
     {:error, [starting_balance: :invalid_amount]} =
-      OpValidate.validate_amount({:starting_balance, "100"})
+      Validations.validate_amount({:starting_balance, "100"})
   end
 
   test "validate_optional_amount/1" do
-    {:ok, %Amount{}} = OpValidate.validate_optional_amount({:trust_limit, 100})
+    {:ok, %Amount{}} = Validations.validate_optional_amount({:trust_limit, 100})
   end
 
   test "validate_optional_amount/1 none" do
     {:ok, %Amount{raw: 0x7FFFFFFFFFFFFFFF}} =
-      OpValidate.validate_optional_amount({:trust_limit, nil})
+      Validations.validate_optional_amount({:trust_limit, nil})
   end
 
   test "validate_optional_amount/1 error" do
     {:error, [trust_limit: :invalid_amount]} =
-      OpValidate.validate_optional_amount({:trust_limit, "2"})
+      Validations.validate_optional_amount({:trust_limit, "2"})
   end
 
   test "validate_asset/1" do
-    {:ok, %Asset{}} = OpValidate.validate_asset({:asset, :native})
+    {:ok, %Asset{}} = Validations.validate_asset({:asset, :native})
   end
 
   test "validate_asset/1 error" do
     {:error, [dest_asset: :invalid_asset_issuer]} =
-      OpValidate.validate_asset({:dest_asset, {"BTCN", "ABC"}})
+      Validations.validate_asset({:dest_asset, {"BTCN", "ABC"}})
   end
 
   test "validate_optional_assets_path/1", %{account_id: account_id} do
     {:ok, %AssetsPath{}} =
-      OpValidate.validate_optional_assets_path({:path, [:native, {"BTCN", account_id}]})
+      Validations.validate_optional_assets_path({:path, [:native, {"BTCN", account_id}]})
   end
 
   test "validate_optional_assets_path/1 empty_list" do
-    {:ok, %AssetsPath{assets: []}} = OpValidate.validate_optional_assets_path({:path, nil})
+    {:ok, %AssetsPath{assets: []}} = Validations.validate_optional_assets_path({:path, nil})
   end
 
   test "validate_optional_assets_path/1 error" do
     {:error, [path: :invalid_asset_issuer]} =
-      OpValidate.validate_optional_assets_path({:path, [:native, {"BTCN", "ABC"}]})
+      Validations.validate_optional_assets_path({:path, [:native, {"BTCN", "ABC"}]})
   end
 
   test "validate_price/1" do
-    {:ok, %Price{}} = OpValidate.validate_price({:price, 2.15})
+    {:ok, %Price{}} = Validations.validate_price({:price, 2.15})
   end
 
   test "validate_price/1 error" do
-    {:error, [price: :invalid_price]} = OpValidate.validate_price({:price, "2.15"})
+    {:error, [price: :invalid_price]} = Validations.validate_price({:price, "2.15"})
   end
 
   test "validate_claimable_balance_id/1", %{balance_id: balance_id} do
     {:ok, %ClaimableBalanceID{}} =
-      OpValidate.validate_claimable_balance_id({:claimable_balance_id, balance_id})
+      Validations.validate_claimable_balance_id({:claimable_balance_id, balance_id})
   end
 
   test "validate_claimable_balance_id/1 error" do
     {:error, [claimable_balance_id: :invalid_balance_id]} =
-      OpValidate.validate_claimable_balance_id({:claimable_balance_id, "ABC"})
+      Validations.validate_claimable_balance_id({:claimable_balance_id, "ABC"})
   end
 end


### PR DESCRIPTION
Closes #76 

@luishurtado here are my findings after trying other ways to perform validations.

**defdelegate**
* [con] Exposes validation functions as public ones.
* [con] Duplicates code across modules.

**`validate` Behaviour callback**
*  [con] Introduces complexity in the code base when validating multiple data.
*  [con] Duplicates code across modules.

**My proposal:** (prioritizing simplicity and code readability).

1. Implement the `Stellar.TxBuild.Validations` module. 
   * Only used by operation modules.
   * It is not aware of input-data validation. 
   * Ensures that child components/structures used by operations are properly initialized otherwise, returns a formatted error. 

2. Keep data validation in the child components/structures themselves.

3. Make the code more declarative, setting the `only/1` matcher when importing the `Stellar.TxBuild.Validations` module.

LMK, what do you think?

Best!