### PR TITLE
Compose functional Horizon requests 

### DIFF
--- a/lib/horizon/account/balance.ex
+++ b/lib/horizon/account/balance.ex
@@ -8,7 +8,7 @@ defmodule Stellar.Horizon.Account.Balance do
   alias Stellar.Horizon.Mapping
 
   @type t :: %__MODULE__{
-          balance: non_neg_integer(),
+          balance: float(),
           asset_type: String.t(),
           buying_liabilities: float(),
           selling_liabilities: float(),

--- a/lib/horizon/collection.ex
+++ b/lib/horizon/collection.ex
@@ -6,19 +6,14 @@ defmodule Stellar.Horizon.Collection do
 
   @type resource :: module()
   @type records :: [resource(), ...]
-  @type api_response :: map()
+  @type response :: map()
   @type link :: String.t()
-  @type args :: Keyword.t()
-  @type extra_args :: list()
-  @type query_string :: String.t()
 
   @type t :: %__MODULE__{records: records(), self: link(), prev: link(), next: link()}
 
   defstruct [:records, :self, :next, :prev]
 
-  @default_args ~w(cursor order limit)a
-
-  @spec new(response :: {resource(), api_response()}) :: t()
+  @spec new(response :: {resource(), response()}) :: t()
   def new(
         {resource,
          %{
@@ -30,22 +25,4 @@ defmodule Stellar.Horizon.Collection do
   end
 
   def new(_response), do: raise(CollectionError, :invalid_collection)
-
-  @spec query_arguments(args :: args(), extra_args :: list()) :: query_string()
-  def query_arguments(args, opts \\ []) do
-    extra_args = Keyword.get(opts, :extra_args, [])
-
-    args
-    |> Keyword.take(@default_args ++ extra_args)
-    |> Enum.reject(&is_empty_arg/1)
-    |> build_query_string()
-  end
-
-  @spec build_query_string(query :: args()) :: query_string()
-  defp build_query_string([]), do: ""
-  defp build_query_string(query), do: "?" <> URI.encode_query(query)
-
-  @spec is_empty_arg(param :: {atom(), any()}) :: boolean()
-  defp is_empty_arg({_key, nil}), do: true
-  defp is_empty_arg({_key, value}), do: to_string(value) == ""
 end

--- a/lib/horizon/request.ex
+++ b/lib/horizon/request.ex
@@ -95,12 +95,12 @@ defmodule Stellar.Horizon.Request do
   def results(error, _resource), do: error
 
   @spec build_request_url(request :: t()) :: binary()
-  def build_request_url(%__MODULE__{
-        endpoint: endpoint,
-        path: path,
-        segment: segment,
-        encoded_query: encoded_query
-      }) do
+  defp build_request_url(%__MODULE__{
+         endpoint: endpoint,
+         path: path,
+         segment: segment,
+         encoded_query: encoded_query
+       }) do
     IO.iodata_to_binary([
       if(endpoint, do: ["/" | endpoint], else: []),
       if(path, do: ["/" | path], else: []),
@@ -110,12 +110,16 @@ defmodule Stellar.Horizon.Request do
   end
 
   @spec build_query_string(params :: params(), query_params :: query_params()) :: encoded_query()
-  def build_query_string(params, query_params) do
+  defp build_query_string(params, query_params) do
     params
     |> Keyword.take(query_params)
     |> Enum.reject(&is_empty_param/1)
-    |> URI.encode_query()
+    |> encode_query()
   end
+
+  @spec encode_query(query :: query()) :: encoded_query()
+  defp encode_query([]), do: nil
+  defp encode_query(query), do: URI.encode_query(query)
 
   @spec is_empty_param(param :: {atom(), any()}) :: boolean()
   defp is_empty_param({_key, nil}), do: true

--- a/lib/horizon/request.ex
+++ b/lib/horizon/request.ex
@@ -1,0 +1,123 @@
+defmodule Stellar.Horizon.Request do
+  @moduledoc """
+  A module for working with requests to the Horizon API.
+
+  Requests are composed in a functional manner. The request does not happen
+  until it is configured and passed to `perform/1`.
+
+  Generally intended to be used internally, but can also be used by end-users
+  to work around missing endpoints (if any).
+
+  At a minimum, a request must have the endpoint and method specified to be valid.
+  """
+
+  alias Stellar.Horizon.Error
+  alias Stellar.Horizon.Client, as: Horizon
+
+  @type method :: :get | :post
+  @type headers :: [{binary(), binary()}, ...] | []
+  @type body :: Keyword.t()
+  @type query :: Keyword.t()
+  @type encoded_query :: String.t() | nil
+  @type endpoint :: String.t() | nil
+  @type path :: String.t() | nil
+  @type segment :: String.t() | nil
+  @type opts :: Keyword.t()
+  @type params :: Keyword.t()
+  @type query_params :: list(atom())
+  @type response :: {:ok, map()} | {:error, Error.t()}
+  @type parsed_response :: {:ok, struct()} | {:error, Error.t()}
+
+  @type t :: %__MODULE__{
+          method: method(),
+          endpoint: endpoint(),
+          path: path(),
+          segment: segment(),
+          query: query(),
+          headers: headers(),
+          body: body(),
+          encoded_query: encoded_query()
+        }
+
+  defstruct [:method, :headers, :body, :endpoint, :path, :segment, :query, :encoded_query]
+
+  @default_query_params ~w(cursor order limit)a
+
+  @spec new(method :: method(), endpoint :: endpoint(), opts :: opts()) :: t()
+  def new(method, endpoint, opts \\ []) when method in [:get, :post] do
+    path = Keyword.get(opts, :path)
+    segment = Keyword.get(opts, :segment)
+
+    %__MODULE__{
+      method: method,
+      endpoint: endpoint,
+      path: path,
+      segment: segment,
+      query: [],
+      headers: [],
+      body: []
+    }
+  end
+
+  @spec add_body(request :: t(), body :: body()) :: t()
+  def add_body(%__MODULE__{} = request, body) do
+    %{request | body: body}
+  end
+
+  def add_body(_request, _body), do: {:error, :invalid_request_body}
+
+  @spec add_headers(request :: t(), headers :: headers()) :: t()
+  def add_headers(%__MODULE__{} = request, headers) do
+    %{request | headers: headers}
+  end
+
+  @spec add_query(request :: t(), params :: params(), opts :: opts()) :: t()
+  def add_query(request, params \\ [], opts \\ [])
+
+  def add_query(%__MODULE__{} = request, params, opts) do
+    extra_params = Keyword.get(opts, :extra_params, [])
+    query_params = @default_query_params ++ extra_params
+
+    %{request | query: params, encoded_query: build_query_string(params, query_params)}
+  end
+
+  @spec perform(request :: t()) :: response()
+  def perform(%__MODULE__{method: method, headers: headers, body: body} = request) do
+    encoded_body = URI.encode_query(body)
+
+    request
+    |> build_request_url()
+    |> (&Horizon.request(method, &1, headers, encoded_body)).()
+  end
+
+  @spec results(response :: response(), resource :: function()) :: parsed_response()
+  def results({:ok, results}, resource), do: {:ok, resource.(results)}
+  def results(error, _resource), do: error
+
+  @spec build_request_url(request :: t()) :: binary()
+  def build_request_url(%__MODULE__{
+        endpoint: endpoint,
+        path: path,
+        segment: segment,
+        encoded_query: encoded_query
+      }) do
+    IO.iodata_to_binary([
+      if(endpoint, do: ["/" | endpoint], else: []),
+      if(path, do: ["/" | path], else: []),
+      if(segment, do: ["/" | segment], else: []),
+      if(encoded_query, do: ["?" | encoded_query], else: [])
+    ])
+  end
+
+  @spec build_query_string(params :: params(), query_params :: query_params()) :: encoded_query()
+  def build_query_string(params, query_params) do
+    params
+    |> Keyword.take(query_params)
+    |> Enum.reject(&is_empty_param/1)
+    |> URI.encode_query()
+  end
+
+  @spec is_empty_param(param :: {atom(), any()}) :: boolean()
+  defp is_empty_param({_key, nil}), do: true
+  defp is_empty_param({_key, value}), do: to_string(value) == ""
+end

--- a/test/horizon/collection_test.exs
+++ b/test/horizon/collection_test.exs
@@ -37,26 +37,4 @@ defmodule Stellar.Horizon.CollectionTest do
       } = Collection.new({Transaction, response})
     end
   end
-
-  describe "query_arguments/2" do
-    test "valid" do
-      "?cursor=12345&order=desc&limit=25" =
-        Collection.query_arguments(cursor: 12_345, order: :desc, limit: 25)
-    end
-
-    test "extra_arguments" do
-      "?cursor=12345&include_failed=true" =
-        Collection.query_arguments([cursor: 12_345, include_failed: true],
-          extra_args: [:include_failed]
-        )
-    end
-
-    test "invalid_arguments" do
-      "?cursor=12345" = Collection.query_arguments(cursor: 12_345, test: true)
-    end
-
-    test "no_arguments" do
-      "" = Collection.query_arguments([])
-    end
-  end
 end

--- a/test/horizon/request_test.exs
+++ b/test/horizon/request_test.exs
@@ -1,0 +1,136 @@
+defmodule Stellar.Horizon.Client.CannedRequestImpl do
+  @moduledoc false
+
+  @behaviour Stellar.Horizon.Client.Spec
+
+  @impl true
+  def request(_method, "/transactions/f08b8/effects?limit=10", _headers, _body, _opts) do
+    send(self(), {:horizon_requested, 200})
+    {:ok, 200, [], nil}
+  end
+end
+
+defmodule Stellar.Horizon.RequestTest do
+  use ExUnit.Case
+
+  alias Stellar.Test.Fixtures.Horizon
+  alias Stellar.Horizon.Client.CannedRequestImpl
+  alias Stellar.Horizon.{Collection, Error, Request, Transaction}
+
+  setup do
+    Application.put_env(:stellar_sdk, :http_client_impl, CannedRequestImpl)
+
+    on_exit(fn ->
+      Application.delete_env(:stellar_sdk, :http_client_impl)
+    end)
+
+    endpoint = "transactions"
+    hash = "f08b83906eaebfbf359182cc1e47a0e5c4bbdbad1a897785d5677a2bfc54b5b1"
+    body = [tx: "AAAAAgAAABAAAAAAAAAA==="]
+    headers = [{"Content-Type", "application/x-www-form-urlencoded"}]
+    query = [cursor: "549755817992-1", order: "desc", limit: 25]
+
+    %{endpoint: endpoint, hash: hash, body: body, headers: headers, query: query}
+  end
+
+  test "new/1", %{endpoint: endpoint, hash: hash} do
+    %Request{method: :get, endpoint: ^endpoint, path: ^hash, body: [], headers: [], query: []} =
+      Request.new(:get, endpoint, path: hash)
+  end
+
+  test "add_body/2", %{endpoint: endpoint, body: body} do
+    %Request{method: :post, endpoint: ^endpoint, body: ^body} =
+      :post
+      |> Request.new(endpoint)
+      |> Request.add_body(body)
+  end
+
+  test "add_headers/2", %{endpoint: endpoint, headers: headers} do
+    %Request{method: :post, endpoint: ^endpoint, headers: ^headers} =
+      :post
+      |> Request.new(endpoint)
+      |> Request.add_headers(headers)
+  end
+
+  test "add_query/3", %{endpoint: endpoint, query: query} do
+    %Request{
+      method: :get,
+      endpoint: ^endpoint,
+      query: ^query,
+      encoded_query: "cursor=549755817992-1&order=desc&limit=25"
+    } =
+      :get
+      |> Request.new(endpoint)
+      |> Request.add_query(query)
+  end
+
+  test "add_query/3 extra_params", %{endpoint: endpoint, query: query} do
+    query = query ++ [include_failed: true]
+
+    %Request{
+      method: :get,
+      endpoint: ^endpoint,
+      query: ^query,
+      encoded_query: "cursor=549755817992-1&order=desc&limit=25&include_failed=true"
+    } =
+      :get
+      |> Request.new(endpoint)
+      |> Request.add_query(query, extra_params: [:include_failed])
+  end
+
+  test "add_query/3 invalid_params", %{endpoint: endpoint} do
+    %Request{
+      method: :get,
+      endpoint: ^endpoint,
+      encoded_query: "cursor=549755817992-1"
+    } =
+      :get
+      |> Request.new(endpoint)
+      |> Request.add_query([cursor: "549755817992-1", test: "test"],
+        extra_params: [:include_failed]
+      )
+  end
+
+  test "perform/2" do
+    :get
+    |> Request.new("transactions", path: "f08b8", segment: "effects")
+    |> Request.add_query(limit: 10)
+    |> Request.perform()
+
+    assert_receive({:horizon_requested, 200})
+  end
+
+  test "results/2 success" do
+    body = Horizon.fixture("transaction")
+    transaction = Jason.decode!(body, keys: :atoms)
+
+    {:ok,
+     %Transaction{
+       hash: "132c440e984ab97d895f3477015080aafd6c4375f6a70a87327f7f95e13c4e31",
+       ledger: 27_956_256
+     }} = Request.results({:ok, transaction}, &Transaction.new(&1))
+  end
+
+  test "results/2 collection" do
+    body = Horizon.fixture("transactions")
+    transactions = Jason.decode!(body, keys: :atoms)
+
+    {:ok,
+     %Collection{
+       records: [
+         %Transaction{hash: "3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8889"},
+         %Transaction{hash: "2db4b22ca018119c5027a80578813ffcf582cda4aa9e31cd92b43cf1bda4fc5a"},
+         %Transaction{hash: "3ce2aca2fed36da2faea31352c76c5e412348887a4c119b1e90de8d1b937396a"}
+       ],
+       next:
+         "https://horizon.stellar.org/transactions?cursor=33736968114176\u0026limit=3\u0026order=asc",
+       prev:
+         "https://horizon.stellar.org/transactions?cursor=12884905984\u0026limit=3\u0026order=desc",
+       self: "https://horizon.stellar.org/transactions?cursor=\u0026limit=3\u0026order=asc"
+     }} = Request.results({:ok, transactions}, &Collection.new({Transaction, &1}))
+  end
+
+  test "results/2 error" do
+    {:error, %Error{}} = Request.results({:error, %Error{}}, &Collection.new({Transaction, &1}))
+  end
+end


### PR DESCRIPTION
This PR allows composing functional requests for all Horizon's endpoints.

```elixir
  def create(base64_envelope) do
    :post
    |> Request.new("transactions")
    |> Request.add_headers([{"Content-Type", "application/x-www-form-urlencoded"}])
    |> Request.add_body(tx: base64_envelope)
    |> Request.perform()
    |> Request.results(&Transaction.new(&1))
  end
```