### PR TITLE
Complement modules ClaimPredicate & SetTrustlineFlags

### DIFF
--- a/lib/tx_build/claim_predicate.ex
+++ b/lib/tx_build/claim_predicate.ex
@@ -27,8 +27,8 @@ defmodule Stellar.TxBuild.ClaimPredicate do
 
   def new(:unconditional, _opts), do: %__MODULE__{predicate: :unconditional}
 
-  def new({value, type, time_type}, _opts),
-    do: new(value: value, type: type, time_type: time_type)
+  def new({value, type}, _opts),
+    do: new(value: value, type: type)
 
   def new([value: value, type: type], _opts)
       when type in ~w(and or not)a do
@@ -40,6 +40,9 @@ defmodule Stellar.TxBuild.ClaimPredicate do
         {:error, value}
     end
   end
+
+  def new({value, type, time_type}, _opts),
+    do: new(value: value, type: type, time_type: time_type)
 
   def new([value: value, type: type, time_type: time_type], _opts) do
     case validate_predicate_value(value, type) do

--- a/lib/tx_build/optional_claim_predicate.ex
+++ b/lib/tx_build/optional_claim_predicate.ex
@@ -14,6 +14,8 @@ defmodule Stellar.TxBuild.OptionalClaimPredicate do
   @impl true
   def new(predicate \\ nil, opts \\ [])
 
+  def new(nil, _opts), do: %__MODULE__{value: nil}
+
   def new(%ClaimPredicate{} = predicate, _opts) do
     %__MODULE__{value: predicate}
   end
@@ -21,6 +23,8 @@ defmodule Stellar.TxBuild.OptionalClaimPredicate do
   def new(_args, _opts), do: {:error, :invalid_optional_claim_predicate}
 
   @impl true
+  def to_xdr(%__MODULE__{value: nil}), do: OptionalClaimPredicate.new()
+
   def to_xdr(%__MODULE__{value: predicate}) do
     predicate
     |> ClaimPredicate.to_xdr()

--- a/lib/tx_build/optional_claim_predicate.ex
+++ b/lib/tx_build/optional_claim_predicate.ex
@@ -18,13 +18,9 @@ defmodule Stellar.TxBuild.OptionalClaimPredicate do
     %__MODULE__{value: predicate}
   end
 
-  def new(nil, _opts), do: %__MODULE__{value: nil}
-
   def new(_args, _opts), do: {:error, :invalid_optional_claim_predicate}
 
   @impl true
-  def to_xdr(%__MODULE__{value: nil}), do: OptionalClaimPredicate.new()
-
   def to_xdr(%__MODULE__{value: predicate}) do
     predicate
     |> ClaimPredicate.to_xdr()

--- a/test/support/fixtures/xdr.ex
+++ b/test/support/fixtures/xdr.ex
@@ -52,6 +52,7 @@ defmodule Stellar.Test.Fixtures.XDR do
   defdelegate claim_predicate_time_relative(value, type, time_type), to: Predicates
   defdelegate claim_predicates(value), to: Predicates
   defdelegate optional_predicate(value), to: Predicates
+  defdelegate optional_predicate_with_nil_value(value), to: Predicates
 
   # ledger entries
   defdelegate ledger_account(account_id), to: Ledger

--- a/test/support/fixtures/xdr/predicates.ex
+++ b/test/support/fixtures/xdr/predicates.ex
@@ -229,4 +229,9 @@ defmodule Stellar.Test.Fixtures.XDR.Predicates do
       }
     }
   end
+
+  @spec optional_predicate_with_nil_value(value :: nil) :: OptionalClaimPredicate.t()
+  def optional_predicate_with_nil_value(nil) do
+    %OptionalClaimPredicate{predicate: nil}
+  end
 end

--- a/test/tx_build/claim_predicate_test.exs
+++ b/test/tx_build/claim_predicate_test.exs
@@ -37,6 +37,11 @@ defmodule Stellar.TxBuild.ClaimPredicateTest do
     %ClaimPredicate{predicate: :unconditional} = ClaimPredicate.new(:unconditional)
   end
 
+  test "new/2 tuple_with_2_arguments", %{predicates: value} do
+    %ClaimPredicate{predicate: :conditional, value: ^value, type: :and} =
+      ClaimPredicate.new({value, :and})
+  end
+
   test "new/2 and_type", %{predicates: predicates} do
     %ClaimPredicate{predicate: :conditional, value: ^predicates, type: :and} =
       ClaimPredicate.new(value: predicates, type: :and)
@@ -78,6 +83,15 @@ defmodule Stellar.TxBuild.ClaimPredicateTest do
       type: :time,
       time_type: :absolute
     } = ClaimPredicate.new(value: value, type: :time, time_type: :absolute)
+  end
+
+  test "new/2 tuple_with_3_arguments", %{value_time: value} do
+    %ClaimPredicate{
+      predicate: :conditional,
+      value: ^value,
+      type: :time,
+      time_type: :absolute
+    } = ClaimPredicate.new({value, :time, :absolute})
   end
 
   test "new/2 time_type_absolute_invalid", %{predicate: predicate} do

--- a/test/tx_build/optional_claim_predicate_test.exs
+++ b/test/tx_build/optional_claim_predicate_test.exs
@@ -9,12 +9,17 @@ defmodule Stellar.TxBuild.OptionalClaimPredicateTest do
 
     %{
       predicate: predicate,
-      xdr: XDRFixtures.optional_predicate(predicate)
+      xdr: XDRFixtures.optional_predicate(predicate),
+      xdr_nil: XDRFixtures.optional_predicate_with_nil_value(nil)
     }
   end
 
   test "new/2", %{predicate: predicate} do
     %OptionalClaimPredicate{value: ^predicate} = OptionalClaimPredicate.new(predicate)
+  end
+
+  test "new/2 with_nil_value" do
+    %OptionalClaimPredicate{value: nil} = OptionalClaimPredicate.new(nil)
   end
 
   test "new/2 invalid_optional_claim_predicate" do
@@ -24,6 +29,13 @@ defmodule Stellar.TxBuild.OptionalClaimPredicateTest do
   test "to_xdr/1", %{predicate: value, xdr: xdr} do
     ^xdr =
       value
+      |> OptionalClaimPredicate.new()
+      |> OptionalClaimPredicate.to_xdr()
+  end
+
+  test "to_xdr/1 with_nil_value", %{xdr_nil: xdr} do
+    ^xdr =
+      nil
       |> OptionalClaimPredicate.new()
       |> OptionalClaimPredicate.to_xdr()
   end

--- a/test/tx_build/set_trustline_flags_test.exs
+++ b/test/tx_build/set_trustline_flags_test.exs
@@ -48,6 +48,18 @@ defmodule Stellar.TxBuild.SetTrustlineFlagsTest do
       )
   end
 
+  test "new/2 invalid_flags", %{
+    trustor: trustor,
+    asset: asset
+  } do
+    {:error, [set_flags: :invalid_flags]} =
+      SetTrustlineFlags.new(
+        trustor: trustor,
+        asset: asset,
+        set_flags: :test
+      )
+  end
+
   test "new/2 with_invalid_trustor" do
     {:error, [trustor: :invalid_ed25519_public_key]} =
       SetTrustlineFlags.new(


### PR DESCRIPTION
**Description**

`Stellar.TxBuild.ClaimPredicate` module code improved and testing completed

In the `Stellar.TxBuild.OptionalClaimPredicate` the tests were completed.

For `Stellar.TxBuild.SetTrustlineFlags` the tests were completed

**Screenshots**
<img width="538" alt="Screen Shot 2022-05-05 at 4 46 14 PM" src="https://user-images.githubusercontent.com/2568221/167032026-767d8135-b1cd-4c21-ac65-925356f7663b.png">
<img width="526" alt="Screen Shot 2022-05-05 at 4 46 35 PM" src="https://user-images.githubusercontent.com/2568221/167032039-c934bc0b-82a6-4c94-b38c-0cf22fa747e7.png">
<img width="533" alt="Screen Shot 2022-05-05 at 4 46 59 PM" src="https://user-images.githubusercontent.com/2568221/167032056-85907d4e-ba1b-40d5-a9dc-c5aff5256b02.png">

