### PR TITLE
Add Claimant struct with the respective tests

### DIFF
--- a/lib/tx_build/claim_predicate.ex
+++ b/lib/tx_build/claim_predicate.ex
@@ -94,17 +94,17 @@ defmodule Stellar.TxBuild.ClaimPredicate do
   end
 
   @spec validate_predicate_value(value :: value(), type :: atom()) :: validation()
-  def validate_predicate_value(%__MODULE__{} = value, type)
-      when type != :time,
-      do: {:ok, value}
+  defp validate_predicate_value(%__MODULE__{} = value, type)
+       when type != :time,
+       do: {:ok, value}
 
-  def validate_predicate_value(value, :time) when is_integer(value),
+  defp validate_predicate_value(value, :time) when is_integer(value),
     do: {:ok, value}
 
-  def validate_predicate_value(%ClaimPredicates{value: value}, type)
-      when is_list(value) and length(value) == 2 and
-             type in ~w(and or)a,
-      do: ClaimPredicates.validate_predicate_list([], value)
+  defp validate_predicate_value(%ClaimPredicates{value: value}, type)
+       when is_list(value) and length(value) == 2 and
+              type in ~w(and or)a,
+       do: ClaimPredicates.validate_predicate_list([], value)
 
-  def validate_predicate_value(_value, _type), do: {:error, :invalid_predicate_value}
+  defp validate_predicate_value(_value, _type), do: {:error, :invalid_predicate_value}
 end

--- a/lib/tx_build/claim_predicate.ex
+++ b/lib/tx_build/claim_predicate.ex
@@ -94,17 +94,17 @@ defmodule Stellar.TxBuild.ClaimPredicate do
   end
 
   @spec validate_predicate_value(value :: value(), type :: atom()) :: validation()
-  defp validate_predicate_value(%__MODULE__{} = value, type)
-       when type != :time,
-       do: {:ok, value}
+  def validate_predicate_value(%__MODULE__{} = value, type)
+      when type != :time,
+      do: {:ok, value}
 
-  defp validate_predicate_value(value, :time) when is_integer(value),
+  def validate_predicate_value(value, :time) when is_integer(value),
     do: {:ok, value}
 
-  defp validate_predicate_value(%ClaimPredicates{value: value}, type)
-       when is_list(value) and length(value) == 2 and
-              type in ~w(and or)a,
-       do: ClaimPredicates.validate_predicate_list([], value)
+  def validate_predicate_value(%ClaimPredicates{value: value}, type)
+      when is_list(value) and length(value) == 2 and
+             type in ~w(and or)a,
+      do: ClaimPredicates.validate_predicate_list([], value)
 
-  defp validate_predicate_value(_value, _type), do: {:error, :invalid_predicate_value}
+  def validate_predicate_value(_value, _type), do: {:error, :invalid_predicate_value}
 end

--- a/lib/tx_build/claim_predicate.ex
+++ b/lib/tx_build/claim_predicate.ex
@@ -107,4 +107,30 @@ defmodule Stellar.TxBuild.ClaimPredicate do
       do: ClaimPredicates.validate_predicate_list([], value)
 
   def validate_predicate_value(_value, _type), do: {:error, :invalid_predicate_value}
+
+  @spec validate_predicate(issuer :: t()) :: validation()
+  def validate_predicate(%__MODULE__{predicate: :unconditional} = predicate),
+    do: {:ok, predicate}
+
+  def validate_predicate(%__MODULE__{value: value, type: :time, time_type: time_type}) do
+    case new({value, :time, time_type}) do
+      {:error, _value} ->
+        {:error, :invalid_claim_predicate}
+
+      predicate ->
+        {:ok, predicate}
+    end
+  end
+
+  def validate_predicate(%__MODULE__{value: value, type: type}) do
+    case new({value, type}) do
+      {:error, _value} ->
+        {:error, :invalid_claim_predicate}
+
+      predicate ->
+        {:ok, predicate}
+    end
+  end
+
+  def validate_predicate(_predicate), do: {:error, :invalid_claim_predicate}
 end

--- a/lib/tx_build/claim_predicate.ex
+++ b/lib/tx_build/claim_predicate.ex
@@ -107,30 +107,4 @@ defmodule Stellar.TxBuild.ClaimPredicate do
       do: ClaimPredicates.validate_predicate_list([], value)
 
   def validate_predicate_value(_value, _type), do: {:error, :invalid_predicate_value}
-
-  @spec validate_predicate(issuer :: t()) :: validation()
-  def validate_predicate(%__MODULE__{predicate: :unconditional} = predicate),
-    do: {:ok, predicate}
-
-  def validate_predicate(%__MODULE__{value: value, type: :time, time_type: time_type}) do
-    case new({value, :time, time_type}) do
-      {:error, _value} ->
-        {:error, :invalid_claim_predicate}
-
-      predicate ->
-        {:ok, predicate}
-    end
-  end
-
-  def validate_predicate(%__MODULE__{value: value, type: type}) do
-    case new({value, type}) do
-      {:error, _value} ->
-        {:error, :invalid_claim_predicate}
-
-      predicate ->
-        {:ok, predicate}
-    end
-  end
-
-  def validate_predicate(_predicate), do: {:error, :invalid_claim_predicate}
 end

--- a/lib/tx_build/claimant.ex
+++ b/lib/tx_build/claimant.ex
@@ -7,28 +7,27 @@ defmodule Stellar.TxBuild.Claimant do
       validate_account_id: 1
     ]
 
-  alias Stellar.TxBuild.AccountID
-  alias Stellar.TxBuild.ClaimPredicate, as: TxClaimPredicate
+  alias Stellar.TxBuild.{AccountID, ClaimPredicate}
   alias StellarBase.XDR.{ClaimantV0, Claimant, ClaimantType}
 
   @behaviour Stellar.TxBuild.XDR
 
   @type validation :: {:ok, any()} | {:error, atom()}
 
-  @type t :: %__MODULE__{destination: String.t(), predicate: TxClaimPredicate.t()}
+  @type t :: %__MODULE__{destination: String.t(), predicate: ClaimPredicate.t()}
 
   defstruct [:destination, :predicate]
 
   @impl true
   def new(args, opts \\ [])
 
-  def new({destination, predicate}, _opts),
+  def new({destination, %ClaimPredicate{} = predicate}, _opts),
     do: new(destination: destination, predicate: predicate)
 
-  def new([destination: destination, predicate: predicate], _opts) do
-    with {:ok, destination} <- validate_account_id({:destination, destination}),
-         {:ok, predicate} <- TxClaimPredicate.validate_predicate(predicate) do
-      %__MODULE__{destination: destination, predicate: predicate}
+  def new([destination: destination, predicate: %ClaimPredicate{} = predicate], _opts) do
+    case validate_account_id({:destination, destination}) do
+      {:ok, destination} -> %__MODULE__{destination: destination, predicate: predicate}
+      _error -> {:error, :invalid_account_id}
     end
   end
 
@@ -37,7 +36,7 @@ defmodule Stellar.TxBuild.Claimant do
   @impl true
   def to_xdr(%__MODULE__{destination: destination, predicate: predicate}) do
     destination = AccountID.to_xdr(destination)
-    claim_predicate = TxClaimPredicate.to_xdr(predicate)
+    claim_predicate = ClaimPredicate.to_xdr(predicate)
     claimant_type = ClaimantType.new(:CLAIMANT_TYPE_V0)
 
     destination

--- a/lib/tx_build/claimant.ex
+++ b/lib/tx_build/claimant.ex
@@ -1,0 +1,67 @@
+defmodule Stellar.TxBuild.Claimant do
+  @moduledoc """
+  `Claimant` struct definition.
+  """
+  import Stellar.TxBuild.Validations,
+    only: [
+      validate_account_id: 1
+    ]
+
+  alias Stellar.TxBuild.AccountID
+  alias Stellar.TxBuild.ClaimPredicate, as: TxClaimPredicate
+  alias StellarBase.XDR.{ClaimantV0, Claimant, ClaimantType}
+
+  @behaviour Stellar.TxBuild.XDR
+
+  @type validation :: {:ok, any()} | {:error, atom()}
+
+  @type t :: %__MODULE__{destination: String.t(), predicate: TxClaimPredicate.t()}
+
+  defstruct [:destination, :predicate]
+
+  @impl true
+  def new(args, opts \\ [])
+
+  def new({destination, predicate}, _opts),
+    do: new(destination: destination, predicate: predicate)
+
+  def new([destination: destination, predicate: predicate], _opts) do
+    with {:ok, destination} <- validate_account_id({:destination, destination}),
+         {:ok, predicate} <- validate_predicate(predicate) do
+      %__MODULE__{destination: destination, predicate: predicate}
+    end
+  end
+
+  def new(_args, _opts), do: {:error, :invalid_claimant}
+
+  @impl true
+  def to_xdr(%__MODULE__{destination: destination, predicate: predicate}) do
+    destination = AccountID.to_xdr(destination)
+
+    claim_predicate =
+      predicate
+      |> TxClaimPredicate.to_xdr()
+
+    claimant_type = ClaimantType.new(:CLAIMANT_TYPE_V0)
+
+    destination
+    |> ClaimantV0.new(claim_predicate)
+    |> Claimant.new(claimant_type)
+  end
+
+  @spec validate_predicate(issuer :: TxClaimPredicate.t()) :: validation()
+  defp validate_predicate(%TxClaimPredicate{predicate: :unconditional} = predicate),
+    do: {:ok, predicate}
+
+  defp validate_predicate(%TxClaimPredicate{type: type} = predicate) do
+    case TxClaimPredicate.validate_predicate_value(predicate, type) do
+      {:ok, destination} ->
+        {:ok, destination}
+
+      _error ->
+        {:error, :invalid_claim_predicate}
+    end
+  end
+
+  defp validate_predicate(_predicate), do: {:error, :invalid_claim_predicate}
+end

--- a/lib/tx_build/claimant.ex
+++ b/lib/tx_build/claimant.ex
@@ -27,7 +27,7 @@ defmodule Stellar.TxBuild.Claimant do
 
   def new([destination: destination, predicate: predicate], _opts) do
     with {:ok, destination} <- validate_account_id({:destination, destination}),
-         {:ok, predicate} <- validate_predicate(predicate) do
+         {:ok, predicate} <- TxClaimPredicate.validate_predicate(predicate) do
       %__MODULE__{destination: destination, predicate: predicate}
     end
   end
@@ -37,31 +37,11 @@ defmodule Stellar.TxBuild.Claimant do
   @impl true
   def to_xdr(%__MODULE__{destination: destination, predicate: predicate}) do
     destination = AccountID.to_xdr(destination)
-
-    claim_predicate =
-      predicate
-      |> TxClaimPredicate.to_xdr()
-
+    claim_predicate = TxClaimPredicate.to_xdr(predicate)
     claimant_type = ClaimantType.new(:CLAIMANT_TYPE_V0)
 
     destination
     |> ClaimantV0.new(claim_predicate)
     |> Claimant.new(claimant_type)
   end
-
-  @spec validate_predicate(issuer :: TxClaimPredicate.t()) :: validation()
-  defp validate_predicate(%TxClaimPredicate{predicate: :unconditional} = predicate),
-    do: {:ok, predicate}
-
-  defp validate_predicate(%TxClaimPredicate{type: type} = predicate) do
-    case TxClaimPredicate.validate_predicate_value(predicate, type) do
-      {:ok, destination} ->
-        {:ok, destination}
-
-      _error ->
-        {:error, :invalid_claim_predicate}
-    end
-  end
-
-  defp validate_predicate(_predicate), do: {:error, :invalid_claim_predicate}
 end

--- a/test/support/fixtures/xdr.ex
+++ b/test/support/fixtures/xdr.ex
@@ -65,6 +65,7 @@ defmodule Stellar.Test.Fixtures.XDR do
   defdelegate claim_predicates(value), to: Predicates
   defdelegate optional_predicate(value), to: Predicates
   defdelegate optional_predicate_with_nil_value(value), to: Predicates
+  defdelegate claimant(destination, predicate), to: Predicates
 
   # ledger entries
   defdelegate ledger_account(account_id), to: Ledger

--- a/test/support/fixtures/xdr/predicates.ex
+++ b/test/support/fixtures/xdr/predicates.ex
@@ -8,7 +8,14 @@ defmodule Stellar.Test.Fixtures.XDR.Predicates do
     ClaimPredicateType,
     Int64,
     OptionalClaimPredicate,
-    Void
+    Void,
+    Claimant,
+    ClaimantV0,
+    AccountID,
+    PublicKey,
+    UInt256,
+    PublicKeyType,
+    ClaimantType
   }
 
   alias Stellar.TxBuild.ClaimPredicate, as: TxClaimPredicate
@@ -233,5 +240,52 @@ defmodule Stellar.Test.Fixtures.XDR.Predicates do
   @spec optional_predicate_with_nil_value(value :: nil) :: OptionalClaimPredicate.t()
   def optional_predicate_with_nil_value(nil) do
     %OptionalClaimPredicate{predicate: nil}
+  end
+
+  @spec claimant(destination :: String.t(), predicate :: value()) :: Claimant.t()
+  def claimant(
+        "GBTG2POJVVSRBQSZVA3IYJEZJQLPTIVVYOYRLTZEAEFBMVP72ZTQYA2V",
+        %TxClaimPredicate{
+          predicate: :conditional,
+          time_type: nil,
+          type: :not,
+          value: %Stellar.TxBuild.ClaimPredicate{
+            predicate: :unconditional,
+            time_type: nil,
+            type: nil,
+            value: nil
+          }
+        }
+      ) do
+    %Claimant{
+      claimant: %ClaimantV0{
+        destination: %AccountID{
+          account_id: %PublicKey{
+            public_key: %UInt256{
+              datum:
+                <<102, 109, 61, 201, 173, 101, 16, 194, 89, 168, 54, 140, 36, 153, 76, 22, 249,
+                  162, 181, 195, 177, 21, 207, 36, 1, 10, 22, 85, 255, 214, 103, 12>>
+            },
+            type: %PublicKeyType{
+              identifier: :PUBLIC_KEY_TYPE_ED25519
+            }
+          }
+        },
+        predicate: %ClaimPredicate{
+          predicate: %OptionalClaimPredicate{
+            predicate: %ClaimPredicate{
+              predicate: %Void{value: nil},
+              type: %ClaimPredicateType{
+                identifier: :CLAIM_PREDICATE_UNCONDITIONAL
+              }
+            }
+          },
+          type: %ClaimPredicateType{
+            identifier: :CLAIM_PREDICATE_NOT
+          }
+        }
+      },
+      type: %ClaimantType{identifier: :CLAIMANT_TYPE_V0}
+    }
   end
 end

--- a/test/tx_build/claimant_test.exs
+++ b/test/tx_build/claimant_test.exs
@@ -15,10 +15,13 @@ defmodule Stellar.TxBuild.ClaimantTest do
         type: :not
       )
 
+    predicate3 = ClaimPredicate.new(value: 1, type: :time, time_type: :absolute)
+
     %{
       destination: destination,
       predicate_unconditional: predicate1,
       predicate: predicate2,
+      predicate_time: predicate3,
       xdr_claimant: XDRFixtures.claimant(destination, predicate2)
     }
   end
@@ -40,6 +43,16 @@ defmodule Stellar.TxBuild.ClaimantTest do
   test "new/2 unconditional_predicate", %{
     destination: destination,
     predicate_unconditional: predicate
+  } do
+    destination_str = AccountID.new(destination)
+
+    %Claimant{destination: ^destination_str, predicate: ^predicate} =
+      Claimant.new(destination: destination, predicate: predicate)
+  end
+
+  test "new/2 time_predicate", %{
+    destination: destination,
+    predicate_time: predicate
   } do
     destination_str = AccountID.new(destination)
 

--- a/test/tx_build/claimant_test.exs
+++ b/test/tx_build/claimant_test.exs
@@ -1,0 +1,73 @@
+defmodule Stellar.TxBuild.ClaimantTest do
+  use ExUnit.Case
+
+  alias Stellar.Test.Fixtures.XDR, as: XDRFixtures
+
+  alias Stellar.TxBuild.{ClaimPredicate, Claimant, AccountID}
+
+  setup do
+    destination = "GBTG2POJVVSRBQSZVA3IYJEZJQLPTIVVYOYRLTZEAEFBMVP72ZTQYA2V"
+    predicate1 = ClaimPredicate.new(:unconditional)
+
+    predicate2 =
+      ClaimPredicate.new(
+        value: predicate1,
+        type: :not
+      )
+
+    %{
+      destination: destination,
+      predicate_unconditional: predicate1,
+      predicate: predicate2,
+      xdr_claimant: XDRFixtures.claimant(destination, predicate2)
+    }
+  end
+
+  test "new/2", %{destination: destination, predicate: predicate} do
+    destination_str = AccountID.new(destination)
+
+    %Claimant{destination: ^destination_str, predicate: ^predicate} =
+      Claimant.new(destination: destination, predicate: predicate)
+  end
+
+  test "new/2 tuple_with_arguments", %{destination: destination, predicate: predicate} do
+    destination_str = AccountID.new(destination)
+
+    %Claimant{destination: ^destination_str, predicate: ^predicate} =
+      Claimant.new({destination, predicate})
+  end
+
+  test "new/2 unconditional_predicate", %{
+    destination: destination,
+    predicate_unconditional: predicate
+  } do
+    destination_str = AccountID.new(destination)
+
+    %Claimant{destination: ^destination_str, predicate: ^predicate} =
+      Claimant.new(destination: destination, predicate: predicate)
+  end
+
+  test "new/2 invalid_claimant" do
+    {:error, :invalid_claimant} = Claimant.new("ABC", "ABC")
+  end
+
+  test "new/2 invalid_ed25519_public_key", %{predicate: predicate} do
+    {:error, [destination: :invalid_ed25519_public_key]} =
+      Claimant.new(destination: "ABC", predicate: predicate)
+  end
+
+  test "new/2 invalid_claim_predicate", %{destination: destination} do
+    {:error, :invalid_claim_predicate} = Claimant.new(destination: destination, predicate: "ABC")
+  end
+
+  test "to_xdr/1 time_absolute", %{
+    destination: destination,
+    predicate: predicate,
+    xdr_claimant: xdr
+  } do
+    ^xdr =
+      [destination: destination, predicate: predicate]
+      |> Claimant.new()
+      |> Claimant.to_xdr()
+  end
+end

--- a/test/tx_build/claimant_test.exs
+++ b/test/tx_build/claimant_test.exs
@@ -65,12 +65,7 @@ defmodule Stellar.TxBuild.ClaimantTest do
   end
 
   test "new/2 invalid_ed25519_public_key", %{predicate: predicate} do
-    {:error, [destination: :invalid_ed25519_public_key]} =
-      Claimant.new(destination: "ABC", predicate: predicate)
-  end
-
-  test "new/2 invalid_claim_predicate", %{destination: destination} do
-    {:error, :invalid_claim_predicate} = Claimant.new(destination: destination, predicate: "ABC")
+    {:error, :invalid_account_id} = Claimant.new(destination: "ABC", predicate: predicate)
   end
 
   test "to_xdr/1 time_absolute", %{


### PR DESCRIPTION
**Issue**
#169

**Description**
The Claimant structure is required to create the CreateClaimableBalance operation. The module was defined based on the following UI.

<img width="730" alt="Screen Shot 2022-05-11 at 1 22 29 PM" src="https://user-images.githubusercontent.com/2568221/167919618-4eedd279-0503-4679-84b9-13041135f476.png">

