### PR TITLE
Change TXBuild Signer new input from tuple to keywordlist

### DIFF
--- a/lib/tx_build/signer.ex
+++ b/lib/tx_build/signer.ex
@@ -16,6 +16,8 @@ defmodule Stellar.TxBuild.Signer do
   @impl true
   def new(args, opts \\ [])
 
+  def new([{_key_type, signer_key}, {:weight, weight}], _opts), do: new({signer_key, weight})
+
   def new({signer_key, weight}, _opts) do
     with {:ok, signer_key} <- validate_signer_key(signer_key),
          {:ok, weight} <- validate_signer_weight(weight) do

--- a/test/tx_build/signer_test.exs
+++ b/test/tx_build/signer_test.exs
@@ -33,12 +33,29 @@ defmodule Stellar.TxBuild.SignerTest do
     %Signer{signer_key: ^signer_key, weight: ^weight} = Signer.new({ed25519, 2})
   end
 
+  test "new/2 ed25519 with_input_as_keywordlist", %{
+    ed25519: ed25519,
+    ed25519_signer_key: signer_key,
+    weight: weight
+  } do
+    %Signer{signer_key: ^signer_key, weight: ^weight} = Signer.new(ed25519: ed25519, weight: 2)
+  end
+
   test "new/2 sha256_hash", %{
     sha256_hash: sha256_hash,
     sha256_hash_signer_key: signer_key,
     weight: weight
   } do
     %Signer{signer_key: ^signer_key, weight: ^weight} = Signer.new({sha256_hash, 2})
+  end
+
+  test "new/2 sha256_hash with_input_as_keywordlist", %{
+    sha256_hash: sha256_hash,
+    sha256_hash_signer_key: signer_key,
+    weight: weight
+  } do
+    %Signer{signer_key: ^signer_key, weight: ^weight} =
+      Signer.new(sha256_hash: sha256_hash, weight: 2)
   end
 
   test "new/2 pre_auth_tx", %{
@@ -49,12 +66,30 @@ defmodule Stellar.TxBuild.SignerTest do
     %Signer{signer_key: ^signer_key, weight: ^weight} = Signer.new({pre_auth_tx, 2})
   end
 
+  test "new/2 pre_auth_tx with_input_as_keywordlist", %{
+    pre_auth_tx: pre_auth_tx,
+    pre_auth_tx_signer_key: signer_key,
+    weight: weight
+  } do
+    %Signer{signer_key: ^signer_key, weight: ^weight} =
+      Signer.new(pre_auth_tx: pre_auth_tx, weight: 2)
+  end
+
   test "new/2 signed_payload", %{
     signed_payload: signed_payload,
     signed_payload_signer_key: signer_key,
     weight: weight
   } do
     %Signer{signer_key: ^signer_key, weight: ^weight} = Signer.new({signed_payload, 2})
+  end
+
+  test "new/2 signed_payload with_input_as_keywordlist", %{
+    signed_payload: signed_payload,
+    signed_payload_signer_key: signer_key,
+    weight: weight
+  } do
+    %Signer{signer_key: ^signer_key, weight: ^weight} =
+      Signer.new(signed_payload: signed_payload, weight: 2)
   end
 
   test "new/2 with_invalid_signer_key" do


### PR DESCRIPTION
Closes #217

## Context
On the protocol 19 implementation, the `TXBuild.Signer.new` method input changed from keyword list to tuple since the key type was inferred from the given key, but is easier for a user to ingest the data with a keyword list, so the old version was added again.