### PR TITLE
Expose `hash` and `base_signature` functions in transaction module

### DIFF
--- a/lib/tx_build/transaction.ex
+++ b/lib/tx_build/transaction.ex
@@ -87,7 +87,6 @@ defmodule Stellar.TxBuild.Transaction do
   def hash(tx) do
     tx
     |> base_signature()
-    |> hash_data()
     |> Base.encode16(case: :lower)
   end
 

--- a/lib/tx_build/transaction.ex
+++ b/lib/tx_build/transaction.ex
@@ -3,6 +3,8 @@ defmodule Stellar.TxBuild.Transaction do
   `Transaction` struct definition.
   """
 
+  alias Stellar.Network
+
   alias Stellar.TxBuild.{
     Account,
     BaseFee,
@@ -12,7 +14,11 @@ defmodule Stellar.TxBuild.Transaction do
     Preconditions
   }
 
-  alias StellarBase.XDR.{Ext, Transaction}
+  alias StellarBase.XDR.{Ext, EnvelopeType, TransactionSignaturePayload, Hash}
+
+  alias StellarBase.XDR.Transaction, as: TransactionXDR
+
+  alias StellarBase.XDR.TransactionSignaturePayloadTaggedTransaction, as: TaggedTransaction
 
   @behaviour Stellar.TxBuild.XDR
 
@@ -66,7 +72,7 @@ defmodule Stellar.TxBuild.Transaction do
         memo: memo,
         operations: operations
       }) do
-    Transaction.new(
+    TransactionXDR.new(
       Account.to_xdr(source_account),
       BaseFee.to_xdr(base_fee),
       SequenceNumber.to_xdr(sequence_number),
@@ -76,6 +82,47 @@ defmodule Stellar.TxBuild.Transaction do
       Ext.new()
     )
   end
+
+  @spec hash(tx :: t()) :: String.t()
+  def hash(tx) do
+    tx
+    |> base_signature()
+    |> hash_data()
+    |> Base.encode16(case: :lower)
+  end
+
+  @spec base_signature(tx :: t() | TransactionXDR.t()) :: binary()
+  def base_signature(%__MODULE__{} = tx) do
+    tx
+    |> to_xdr()
+    |> base_signature()
+  end
+
+  def base_signature(%TransactionXDR{} = tx) do
+    envelope_type = EnvelopeType.new(:ENVELOPE_TYPE_TX)
+
+    tx
+    |> TaggedTransaction.new(envelope_type)
+    |> signature_payload()
+  end
+
+  @spec signature_payload(tagged_tx :: struct()) :: binary()
+  def signature_payload(tagged_tx) do
+    network_id_xdr()
+    |> TransactionSignaturePayload.new(tagged_tx)
+    |> TransactionSignaturePayload.encode_xdr!()
+    |> hash_data()
+  end
+
+  @spec network_id_xdr :: Hash.t()
+  def network_id_xdr do
+    Network.passphrase()
+    |> hash_data()
+    |> Hash.new()
+  end
+
+  @spec hash_data(data :: binary()) :: binary()
+  defp hash_data(data), do: :crypto.hash(:sha256, data)
 
   @spec validate_source_account(source_account :: Account.t()) :: validation()
   defp validate_source_account(%Account{} = source_account), do: {:ok, source_account}

--- a/lib/tx_build/transaction_signature.ex
+++ b/lib/tx_build/transaction_signature.ex
@@ -2,28 +2,18 @@ defmodule Stellar.TxBuild.TransactionSignature do
   @moduledoc """
   A module for tagging and signing transactions.
   """
-  alias Stellar.Network
   alias Stellar.TxBuild.{Transaction, Signature}
 
   alias StellarBase.XDR.{
     DecoratedSignatures,
-    EnvelopeType,
-    Hash,
-    TransactionEnvelope,
-    TransactionSignaturePayload
+    TransactionEnvelope
   }
-
-  alias StellarBase.XDR.Transaction, as: TransactionXDR
-  alias StellarBase.XDR.TransactionSignaturePayloadTaggedTransaction, as: TaggedTransaction
 
   @type signatures :: list(Signature.t())
 
   @spec sign(tx :: Transaction.t(), signatures :: signatures()) :: DecoratedSignatures.t()
   def sign(%Transaction{} = tx, signatures) do
-    base_signature =
-      tx
-      |> Transaction.to_xdr()
-      |> base_signature()
+    base_signature = Transaction.base_signature(tx)
 
     signatures
     |> Enum.map(&Signature.to_xdr(&1, base_signature))
@@ -41,37 +31,10 @@ defmodule Stellar.TxBuild.TransactionSignature do
         },
         %Signature{} = signature
       ) do
-    base_signature = base_signature(tx_xdr)
+    base_signature = Transaction.base_signature(tx_xdr)
 
     signature
     |> Signature.to_xdr(base_signature)
     |> (&DecoratedSignatures.new(current_signatures ++ [&1])).()
   end
-
-  @spec base_signature(tx_xdr :: TransactionXDR.t()) :: binary()
-  defp base_signature(%TransactionXDR{} = tx_xdr) do
-    envelope_type = EnvelopeType.new(:ENVELOPE_TYPE_TX)
-
-    tx_xdr
-    |> TaggedTransaction.new(envelope_type)
-    |> signature_payload()
-  end
-
-  @spec signature_payload(tagged_tx :: struct()) :: binary()
-  defp signature_payload(tagged_tx) do
-    network_id_xdr()
-    |> TransactionSignaturePayload.new(tagged_tx)
-    |> TransactionSignaturePayload.encode_xdr!()
-    |> hash()
-  end
-
-  @spec network_id_xdr :: Hash.t()
-  defp network_id_xdr do
-    Network.passphrase()
-    |> hash()
-    |> Hash.new()
-  end
-
-  @spec hash(data :: binary()) :: binary()
-  defp hash(data), do: :crypto.hash(:sha256, data)
 end


### PR DESCRIPTION
Closes #239 

## Description
This change adds the functions previously used by the `TransactionSignature` module into the `Transaction` module, this aims to use the `hash` function to obtain the hash from a transaction.

As the issue mentions, using the `hash` function is possible to create transactions with `pre_auth_tx` signatures.