### PR TITLE
Change initialization entries for setting signer

### DIFF
--- a/lib/tx_build/signer.ex
+++ b/lib/tx_build/signer.ex
@@ -2,10 +2,13 @@ defmodule Stellar.TxBuild.Signer do
   @moduledoc """
   `Signer` struct definition.
   """
-  alias Stellar.TxBuild.{Weight, SignerKey}
-  alias StellarBase.XDR.Signer
 
   @behaviour Stellar.TxBuild.XDR
+
+  alias Stellar.KeyPair
+  alias Stellar.TxBuild.{Weight, SignerKey}
+  alias StellarBase.StrKey
+  alias StellarBase.XDR.{Signer, VariableOpaque64, UInt256, SignerKeyEd25519SignedPayload}
 
   @type validation :: {:ok, any()} | {:error, atom()}
 
@@ -16,7 +19,12 @@ defmodule Stellar.TxBuild.Signer do
   @impl true
   def new(args, opts \\ [])
 
-  def new([{_key_type, signer_key}, {:weight, weight}], _opts), do: new({signer_key, weight})
+  def new([{_signer_type, _signer_key} = signer_key_tuple, {:weight, weight}], _opts) do
+    with {:ok, signer_key} <- validate_signer_key_tuple(signer_key_tuple),
+         {:ok, weight} <- validate_signer_weight(weight) do
+      %__MODULE__{signer_key: signer_key, weight: weight}
+    end
+  end
 
   def new({signer_key, weight}, _opts) do
     with {:ok, signer_key} <- validate_signer_key(signer_key),
@@ -44,7 +52,51 @@ defmodule Stellar.TxBuild.Signer do
     end
   end
 
-  @spec validate_signer_key(signer_key :: String.t()) :: validation()
+  @spec validate_signer_key_tuple(signer_key :: tuple()) :: validation()
+  defp validate_signer_key_tuple({:pre_auth_tx, signer_key}) do
+    with {:ok, raw_pre_auth_tx} <- Base.decode16(signer_key, case: :lower),
+         32 <- byte_size(raw_pre_auth_tx),
+         pre_auth_tx <- StrKey.encode!(raw_pre_auth_tx, :pre_auth_tx) do
+      {:ok, SignerKey.new(pre_auth_tx)}
+    else
+      _ -> {:error, :invalid_signer_key}
+    end
+  end
+
+  defp validate_signer_key_tuple({:hash_x, signer_key}) do
+    with {:ok, raw_hash_x} <- Base.decode16(signer_key, case: :lower),
+         32 <- byte_size(raw_hash_x),
+         hash_x <- StrKey.encode!(raw_hash_x, :sha256_hash) do
+      {:ok, SignerKey.new(hash_x)}
+    else
+      _ -> {:error, :invalid_signer_key}
+    end
+  end
+
+  defp validate_signer_key_tuple({:signed_payload, [ed25519: public_key, payload: payload]}) do
+    with :ok <- KeyPair.validate_public_key(public_key),
+         {:ok, raw_payload} <- Base.decode16(payload, case: :lower),
+         size <- byte_size(raw_payload),
+         true <- size <= 32 do
+      payload_xdr = VariableOpaque64.new(raw_payload)
+
+      signed_payload_signer_key =
+        public_key
+        |> StrKey.decode!(:ed25519_public_key)
+        |> UInt256.new()
+        |> SignerKeyEd25519SignedPayload.new(payload_xdr)
+        |> SignerKeyEd25519SignedPayload.encode_xdr!()
+        |> StrKey.encode!(:signed_payload)
+        |> SignerKey.new()
+
+      {:ok, signed_payload_signer_key}
+    else
+      _ -> {:error, :invalid_signer_key}
+    end
+  end
+
+  defp validate_signer_key_tuple({:ed25519, public_key}), do: validate_signer_key(public_key)
+
   defp validate_signer_key(signer_key) do
     case SignerKey.new(signer_key) do
       %SignerKey{} = signer_key -> {:ok, signer_key}

--- a/lib/tx_build/signer.ex
+++ b/lib/tx_build/signer.ex
@@ -93,7 +93,7 @@ defmodule Stellar.TxBuild.Signer do
     end
   end
 
-  @spec validate_bytes_hex_string(value :: String.t()) :: validation()
+  @spec validate_bytes_hex_string(value :: String.t(), bytes :: integer()) :: validation()
   defp validate_bytes_hex_string(value, bytes \\ 32) do
     with {:ok, raw_value} <- Base.decode16(value, case: :lower),
          ^bytes <- byte_size(raw_value) do

--- a/test/tx_build/set_options_test.exs
+++ b/test/tx_build/set_options_test.exs
@@ -21,26 +21,32 @@ defmodule Stellar.TxBuild.SetOptionsTest do
     clear_flags = []
     set_flags = [:required, :revocable, :inmutable, :clawback_enabled]
     master_weight = 1
-    tresholds = [low: 1, med: 2, high: 3]
+    thresholds = [low: 1, med: 2, high: 3]
     home_domain = "stellar.org"
 
     signer = {"TD3ZRMKMZJBWZMQVA476YZZBT4ORHUCRYTX7RLPO2CKKP2UAPZTOJVEP", 1}
+
+    signer_keyword = [
+      pre_auth_tx: "f798b14cca436cb215073fec67219f1d13d051c4eff8adeed094a7ea807e66e4",
+      weight: 1
+    ]
 
     %{
       inflation_destination: inflation_destination,
       clear_flags: clear_flags,
       set_flags: set_flags,
       master_weight: master_weight,
-      tresholds: tresholds,
+      thresholds: thresholds,
       home_domain: home_domain,
       signer: signer,
+      signer_keyword: signer_keyword,
       xdr:
         set_options_xdr(
           inflation_destination,
           clear_flags,
           set_flags,
           master_weight,
-          tresholds,
+          thresholds,
           home_domain,
           signer
         )
@@ -72,8 +78,33 @@ defmodule Stellar.TxBuild.SetOptionsTest do
       )
   end
 
-  test "new/2 set_tresholds", %{
-    tresholds: [low: low_threshold, med: med_threshold, high: high_threshold]
+  test "new/2 with_signer_keyword", %{
+    inflation_destination: inflation_destination,
+    set_flags: set_flags,
+    master_weight: master_weight,
+    signer_keyword: signer_keyword
+  } do
+    inflation_destination_str = OptionalAccountID.new(inflation_destination)
+    set_flags_str = set_flags |> Flags.new() |> OptionalFlags.new()
+    master_weight_str = master_weight |> Weight.new() |> OptionalWeight.new()
+    signer_str = signer_keyword |> Signer.new() |> OptionalSigner.new()
+
+    %SetOptions{
+      inflation_destination: ^inflation_destination_str,
+      set_flags: ^set_flags_str,
+      master_weight: ^master_weight_str,
+      signer: ^signer_str
+    } =
+      SetOptions.new(
+        inflation_destination: inflation_destination,
+        set_flags: set_flags,
+        master_weight: master_weight,
+        signer: signer_keyword
+      )
+  end
+
+  test "new/2 set_thresholds", %{
+    thresholds: [low: low_threshold, med: med_threshold, high: high_threshold]
   } do
     low_threshold_str = low_threshold |> Weight.new() |> OptionalWeight.new()
     med_threshold_str = med_threshold |> Weight.new() |> OptionalWeight.new()
@@ -128,7 +159,7 @@ defmodule Stellar.TxBuild.SetOptionsTest do
     clear_flags: clear_flags,
     set_flags: set_flags,
     master_weight: master_weight,
-    tresholds: tresholds,
+    thresholds: thresholds,
     home_domain: home_domain,
     signer: signer
   } do
@@ -138,9 +169,9 @@ defmodule Stellar.TxBuild.SetOptionsTest do
         clear_flags: clear_flags,
         set_flags: set_flags,
         master_weight: master_weight,
-        low_threshold: tresholds[:low],
-        medium_threshold: tresholds[:med],
-        high_threshold: tresholds[:high],
+        low_threshold: thresholds[:low],
+        medium_threshold: thresholds[:med],
+        high_threshold: thresholds[:high],
         home_domain: home_domain,
         signer: signer
       )

--- a/test/tx_build/signer_test.exs
+++ b/test/tx_build/signer_test.exs
@@ -15,7 +15,7 @@ defmodule Stellar.TxBuild.SignerTest do
     hex_hash_x = "a6fd63a6cfe7331d6cda52a1a1f1df81f814b6e5709ad3d06f18d414a801b891"
     hex_pre_auth_tx = "aa5326cd097eb68afc3b49381fe6be297a2322a4c59ebef49676a4d892adda2c"
 
-    signed_payload_opts = [
+    signed_payload_keyword = [
       ed25519: "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ",
       payload: "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"
     ]
@@ -28,7 +28,7 @@ defmodule Stellar.TxBuild.SignerTest do
       signed_payload: signed_payload,
       hex_hash_x: hex_hash_x,
       hex_pre_auth_tx: hex_pre_auth_tx,
-      signed_payload_opts: signed_payload_opts,
+      signed_payload_keyword: signed_payload_keyword,
       ed25519_signer_key: SignerKey.new(ed25519),
       hash_x_signer_key: SignerKey.new(hash_x),
       pre_auth_tx_signer_key: SignerKey.new(pre_auth_tx),
@@ -94,12 +94,12 @@ defmodule Stellar.TxBuild.SignerTest do
   end
 
   test "new/2 signed_payload with_input_as_keywordlist", %{
-    signed_payload_opts: signed_payload_opts,
+    signed_payload_keyword: signed_payload_keyword,
     signed_payload_signer_key: signer_key,
     weight: weight
   } do
     %Signer{signer_key: ^signer_key, weight: ^weight} =
-      Signer.new(signed_payload: signed_payload_opts, weight: 2)
+      Signer.new(signed_payload: signed_payload_keyword, weight: 2)
   end
 
   test "new/2 with_invalid_signer_key" do

--- a/test/tx_build/signer_test.exs
+++ b/test/tx_build/signer_test.exs
@@ -6,24 +6,35 @@ defmodule Stellar.TxBuild.SignerTest do
 
   setup do
     ed25519 = "GBTG2POJVVSRBQSZVA3IYJEZJQLPTIVVYOYRLTZEAEFBMVP72ZTQYA2V"
-    sha256_hash = "XCTP2Y5GZ7TTGHLM3JJKDIPR36A7QFFW4VYJVU6QN4MNIFFIAG4JC6CC"
+    hash_x = "XCTP2Y5GZ7TTGHLM3JJKDIPR36A7QFFW4VYJVU6QN4MNIFFIAG4JC6CC"
     pre_auth_tx = "TCVFGJWNBF7LNCX4HNETQH7GXYUXUIZCUTCZ5PXUSZ3KJWESVXNCYN3B"
 
     signed_payload =
       "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAQACAQDAQCQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DUPB6IBZGM"
 
+    hex_hash_x = "a6fd63a6cfe7331d6cda52a1a1f1df81f814b6e5709ad3d06f18d414a801b891"
+    hex_pre_auth_tx = "aa5326cd097eb68afc3b49381fe6be297a2322a4c59ebef49676a4d892adda2c"
+
+    signed_payload_opts = [
+      ed25519: "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ",
+      payload: "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"
+    ]
+
     %{
       weight: Weight.new(2),
       ed25519: ed25519,
-      sha256_hash: sha256_hash,
+      hash_x: hash_x,
       pre_auth_tx: pre_auth_tx,
       signed_payload: signed_payload,
+      hex_hash_x: hex_hash_x,
+      hex_pre_auth_tx: hex_pre_auth_tx,
+      signed_payload_opts: signed_payload_opts,
       ed25519_signer_key: SignerKey.new(ed25519),
-      sha256_hash_signer_key: SignerKey.new(sha256_hash),
+      hash_x_signer_key: SignerKey.new(hash_x),
       pre_auth_tx_signer_key: SignerKey.new(pre_auth_tx),
       signed_payload_signer_key: SignerKey.new(signed_payload),
       ed25519_signer_xdr: XDRFixtures.ed25519_signer(ed25519, 2),
-      sha256_hash_signer_xdr: XDRFixtures.sha256_hash_signer(sha256_hash, 2),
+      hash_x_signer_xdr: XDRFixtures.sha256_hash_signer(hash_x, 2),
       pre_auth_signer_xdr: XDRFixtures.pre_auth_signer(pre_auth_tx, 2),
       signed_payload_signer_xdr: XDRFixtures.ed25519_signed_payload_signer(signed_payload, 2)
     }
@@ -41,21 +52,20 @@ defmodule Stellar.TxBuild.SignerTest do
     %Signer{signer_key: ^signer_key, weight: ^weight} = Signer.new(ed25519: ed25519, weight: 2)
   end
 
-  test "new/2 sha256_hash", %{
-    sha256_hash: sha256_hash,
-    sha256_hash_signer_key: signer_key,
+  test "new/2 hash_x", %{
+    hash_x: hash_x,
+    hash_x_signer_key: signer_key,
     weight: weight
   } do
-    %Signer{signer_key: ^signer_key, weight: ^weight} = Signer.new({sha256_hash, 2})
+    %Signer{signer_key: ^signer_key, weight: ^weight} = Signer.new({hash_x, 2})
   end
 
-  test "new/2 sha256_hash with_input_as_keywordlist", %{
-    sha256_hash: sha256_hash,
-    sha256_hash_signer_key: signer_key,
+  test "new/2 hash_x with_input_as_keywordlist", %{
+    hex_hash_x: hex_hash_x,
+    hash_x_signer_key: signer_key,
     weight: weight
   } do
-    %Signer{signer_key: ^signer_key, weight: ^weight} =
-      Signer.new(sha256_hash: sha256_hash, weight: 2)
+    %Signer{signer_key: ^signer_key, weight: ^weight} = Signer.new(hash_x: hex_hash_x, weight: 2)
   end
 
   test "new/2 pre_auth_tx", %{
@@ -67,12 +77,12 @@ defmodule Stellar.TxBuild.SignerTest do
   end
 
   test "new/2 pre_auth_tx with_input_as_keywordlist", %{
-    pre_auth_tx: pre_auth_tx,
+    hex_pre_auth_tx: hex_pre_auth_tx,
     pre_auth_tx_signer_key: signer_key,
     weight: weight
   } do
     %Signer{signer_key: ^signer_key, weight: ^weight} =
-      Signer.new(pre_auth_tx: pre_auth_tx, weight: 2)
+      Signer.new(pre_auth_tx: hex_pre_auth_tx, weight: 2)
   end
 
   test "new/2 signed_payload", %{
@@ -84,12 +94,12 @@ defmodule Stellar.TxBuild.SignerTest do
   end
 
   test "new/2 signed_payload with_input_as_keywordlist", %{
-    signed_payload: signed_payload,
+    signed_payload_opts: signed_payload_opts,
     signed_payload_signer_key: signer_key,
     weight: weight
   } do
     %Signer{signer_key: ^signer_key, weight: ^weight} =
-      Signer.new(signed_payload: signed_payload, weight: 2)
+      Signer.new(signed_payload: signed_payload_opts, weight: 2)
   end
 
   test "new/2 with_invalid_signer_key" do
@@ -111,9 +121,9 @@ defmodule Stellar.TxBuild.SignerTest do
       |> Signer.to_xdr()
   end
 
-  test "to_xdr/1 sha256_hash", %{sha256_hash_signer_xdr: xdr, sha256_hash: sha256_hash} do
+  test "to_xdr/1 hash_x", %{hash_x_signer_xdr: xdr, hash_x: hash_x} do
     ^xdr =
-      {sha256_hash, 2}
+      {hash_x, 2}
       |> Signer.new()
       |> Signer.to_xdr()
   end


### PR DESCRIPTION
Closes #238 

### Description
This PR updates the `Signer` initialization entries via the `new/2` method which is used when a signer is set up via the `SetOptions` operation.

I decided to make both options available to create a signer:
1. as keyword (more user-friendly)
2. as tuple (strkey encoded- requires more technical knowledge)

