### PR TITLE
Refactor signature signed payload and hash

### DIFF
--- a/lib/tx_build/default.ex
+++ b/lib/tx_build/default.ex
@@ -215,12 +215,13 @@ defmodule Stellar.TxBuild.Default do
   def sign_envelope(_tx_base64, _signature), do: {:error, :invalid_signature}
 
   @impl true
-  def hash(%TxBuild{tx: tx}) do
+  def hash({:ok, %TxBuild{tx: tx}}) do
     tx
     |> Transaction.to_xdr()
     |> TransactionSignature.base_signature()
     |> Base.encode16(case: :lower)
+    |> (&{:ok, &1}).()
   end
 
-  def hash(_tx), do: {:error, :invalid_transaction}
+  def hash(error), do: error
 end

--- a/lib/tx_build/signature.ex
+++ b/lib/tx_build/signature.ex
@@ -47,7 +47,7 @@ defmodule Stellar.TxBuild.Signature do
     end
   end
 
-  def new([signed_payload: {payload, secret}], _opts) do
+  def new([signed_payload: [payload: payload, ed25519: secret]], _opts) do
     with :ok <- validate_payload(payload),
          :ok <- KeyPair.validate_secret_seed(secret),
          do: build_signature(signed_payload: {payload, secret})

--- a/lib/tx_build/spec.ex
+++ b/lib/tx_build/spec.ex
@@ -58,9 +58,10 @@ defmodule Stellar.TxBuild.Spec do
           | SetOptions.t()
   @type operations :: list(operation())
   @type envelope :: String.t()
+  @type hash :: String.t()
   @type tx_build :: {:ok, TxBuild.t()} | {:error, atom()}
   @type tx_envelope :: {:ok, envelope()} | {:error, atom()}
-  @type hash :: {:ok, String.t()} | {:error, atom()}
+  @type tx_hash :: {:ok, hash()} | {:error, atom()}
 
   @callback new(account(), opts()) :: tx_build()
   @callback add_memo(tx_build(), memo()) :: tx_build()
@@ -74,7 +75,7 @@ defmodule Stellar.TxBuild.Spec do
   @callback build(tx_build()) :: tx_build()
   @callback envelope(tx_build()) :: tx_envelope()
   @callback sign_envelope(envelope(), signatures()) :: tx_envelope()
-  @callback hash(tx_build()) :: hash()
+  @callback hash(tx_build()) :: tx_hash()
 
   @optional_callbacks add_memo: 2,
                       set_base_fee: 2,

--- a/lib/tx_build/spec.ex
+++ b/lib/tx_build/spec.ex
@@ -60,7 +60,7 @@ defmodule Stellar.TxBuild.Spec do
   @type envelope :: String.t()
   @type tx_build :: {:ok, TxBuild.t()} | {:error, atom()}
   @type tx_envelope :: {:ok, envelope()} | {:error, atom()}
-  @type hash :: String.t()
+  @type hash :: {:ok, String.t()} | {:error, atom()}
 
   @callback new(account(), opts()) :: tx_build()
   @callback add_memo(tx_build(), memo()) :: tx_build()

--- a/test/tx_build/default_test.exs
+++ b/test/tx_build/default_test.exs
@@ -394,8 +394,8 @@ defmodule Stellar.TxBuild.DefaultTest do
     {:error, :invalid_signature} = TxBuild.envelope({:error, :invalid_signature})
   end
 
-  test "hash/1", %{tx_build: {:ok, tx_build}, tx_hash: tx_hash} do
-    ^tx_hash = TxBuild.hash(tx_build)
+  test "hash/1", %{tx_build: tx_build, tx_hash: tx_hash} do
+    {:ok, ^tx_hash} = TxBuild.hash(tx_build)
   end
 
   test "hash/1 piping_error" do

--- a/test/tx_build/signature_test.exs
+++ b/test/tx_build/signature_test.exs
@@ -97,7 +97,7 @@ defmodule Stellar.TxBuild.SignatureTest do
         secret: secret,
         raw_secret: raw_secret,
         hint: hint,
-        signature: Signature.new(signed_payload: {payload, secret})
+        signature: Signature.new(signed_payload: [payload: payload, ed25519: secret])
       }
     end
 
@@ -113,7 +113,7 @@ defmodule Stellar.TxBuild.SignatureTest do
         key: {^payload, ^secret},
         raw_key: {^raw_payload, ^raw_secret},
         hint: ^hint
-      } = Signature.new(signed_payload: {payload, secret})
+      } = Signature.new(signed_payload: [payload: payload, ed25519: secret])
     end
 
     test "to_xdr/1", %{signature: signature, raw_payload: raw_payload, secret: secret, hint: hint} do


### PR DESCRIPTION
### Description

This PR refactors certain things in order to improve the user experience of the library.

- [x] Refactor `Signature` initialization for `signed_payload` type. 
 
  More descriptive way. Related to #223.
  **Before:**
  ```elixir
  Stellar.TxBuild.Signature.new(signed_payload: {payload, secret_key})
  ```
  
  **Now:**
  ```elixir
  Stellar.TxBuild.Signature.new(signed_payload: [payload: payload, ed25519: secret_key])
  ```
- [x] Refactor `hash/1` function to facilitate piping. 
  
  Now the `hash/1` can be called just next to other functions in the pipeline. Related to #239.
  **Before:**
  ```elixir
  hash(%TxBuild{}} :: String.t()
  ```
  
  **Now:**
  ```elixir
  hash({:ok, %TxBuild{}) :: {:ok, String.t()}
  hash({:error, atom()}) :: {:error, atom()}
  ```