### PR TITLE
Fix documentation paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This library is aimed at developers building Elixir applications that interact w
 The **Stellar SDK** is composed of two complementary components: **`TxBuild`** + **`Horizon`**.
 * **`TxBuild`** - used for [**building transactions.**](#building-transactions)
 * **`Horizon`** - used for [**querying Horizon.**](#querying-horizon)
-* [**Examples.**](/docs/examples.md)
+* [**Examples.**](/docs/README.md)
 
 ## Installation
 [**Available in Hex**][hex], add `stellar_sdk` to your list of dependencies in `mix.exs`:

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,11 +2,11 @@
 
 ## Operations
 
-* [Creating an account](/docs/examples/create_account.md)
-* [Payments](/docs/examples/payments.md)
+* [Creating an account](/docs/examples/operations/create_account.md)
+* [Payments](/docs/examples/operations/payments.md)
 
 ## Signatures
 
-* [Hash(x) Signature](/docs/examples/hash_x.md)
-* [Pre-authorized Transaction Signature](/docs/examples/pre_auth_tx.md)
-* [Ed25519 Signed Payload Signature](/docs/examples/ed25519_signed_payload.md)
+* [Hash(x) Signature](/docs/examples/signatures/hash_x.md)
+* [Pre-authorized Transaction Signature](/docs/examples/signatures/pre_auth_tx.md)
+* [Ed25519 Signed Payload Signature](/docs/examples/signatures/ed25519_signed_payload.md)

--- a/mix.exs
+++ b/mix.exs
@@ -132,20 +132,18 @@ defmodule Stellar.MixProject do
       "README.md",
       "CHANGELOG.md",
       "CONTRIBUTING.md",
-      "docs/README.md",
       "docs/examples/operations/create_account.md",
       "docs/examples/operations/payments.md",
       "docs/examples/signatures/hash_x.md",
       "docs/examples/signatures/pre_auth_tx.md",
-      "docs/examples/signatures/ed25519_signed_payload.md"
+      "docs/examples/signatures/ed25519_signed_payload.md",
+      "docs/README.md": [filename: "examples"]
     ]
   end
 
   defp groups_for_extras do
     [
-      Examples: ~r/^docs\/README.md/,
-      Operations: ~r/docs\/examples\/operations\/.?/,
-      Signatures: ~r/docs\/examples\/signatures\/.?/
+      Examples: ~r/docs\/examples\/.?/
     ]
   end
 end


### PR DESCRIPTION
### Description

There are issues related to the paths of the example guides. Also, the main README was not shown by Hexdocs.
This PR will fix those issues.