### PR TITLE
Enable ExCoveralls with parallel builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,24 @@ jobs:
         run: mix test
       - name: Run Credo
         run: mix credo --strict
-      # - name: Run Excoveralls
-      #   run: mix coveralls.github
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run Excoveralls
+        run: mix coveralls.github --parallel
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  finish:
+    needs: tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set BUILD_NUMBER for Pull Request event
+        if: github.event_name == 'pull_request'
+        run: echo "BUILD_NUMBER=${{ github.event.pull_request.head.sha }}-PR-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+      - name: Set BUILD_NUMBER for Push event
+        if: github.event_name == 'push'
+        run: echo "BUILD_NUMBER=${{ github.sha }}" >> $GITHUB_ENV
+      - name: Publish Coverage Report
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUILD_NUMBER: ${{ env.BUILD_NUMBER }}
+        run: |
+          curl -k "https://coveralls.io/webhook" -d "repo_token=$GITHUB_TOKEN&repo_name=$GITHUB_REPOSITORY&payload[build_num]=${BUILD_NUMBER}&payload[status]=done"


### PR DESCRIPTION
### Description

ExCoveralls had been disabled during the development phase due to exceeding the monthly limits. Also, due to the matrix strategy between the OTP and Elixir versions, 4 builds per workflow were uploaded. See https://github.com/kommitters/stellar_sdk/pull/16#discussion_r747112922

With this approach, the 4 builds are created in parallel, and at the end, they are combined and published to Coveralls.
**More info**: https://docs.coveralls.io/parallel-build-webhook

The **build number** is slightly different between pull requests and pushes. See below:

https://github.com/parroty/excoveralls/blob/d1b6b35cee693e0bc461da00c969a79a23276baa/lib/excoveralls/github.ex#L37-L48