### PR TITLE
Upgraded stellar_base dependency to `v0.8.7` and bump ossf/scorecard-action to `v2.0.6`

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@865b4092859256271290c77adbd10a43f4779972 # tag=v2.0.3
+        uses: ossf/scorecard-action@99c53751e09b9529366343771cc321ec74e9bd3d # tag=v2.0.6
         with:
           results_file: results.sarif
           results_format: sarif

--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule Stellar.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:stellar_base, "~> 0.8.1"},
+      {:stellar_base, "~> 0.8.7"},
       {:ed25519, "~> 1.3"},
       {:hackney, "~> 1.17"},
       {:jason, "~> 1.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -23,6 +23,6 @@
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
   "parse_trans": {:hex, :parse_trans, "3.3.1", "16328ab840cc09919bd10dab29e431da3af9e9e7e7e6f0089dd5a2d2820011d8", [:rebar3], [], "hexpm", "07cd9577885f56362d414e8c4c4e6bdf10d43a8767abb92d24cbe8b24c54888b"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
-  "stellar_base": {:hex, :stellar_base, "0.8.3", "0befa3c40b996190ab88b58e35b59c41e684793f2d59c7dcea4873b7b451d90a", [:mix], [{:crc, "~> 0.10.0", [hex: :crc, repo: "hexpm", optional: false]}, {:elixir_xdr, "~> 0.2.0", [hex: :elixir_xdr, repo: "hexpm", optional: false]}], "hexpm", "fd892ffb983b126c39d4029f8423ca99c8f0613118d7960d8beb7dc4c51175d6"},
+  "stellar_base": {:hex, :stellar_base, "0.8.7", "4d5363d71750199eae0e139a8bb6b00092e0bda4f60211c89ce949a9bcb1b1fb", [:mix], [{:crc, "~> 0.10.0", [hex: :crc, repo: "hexpm", optional: false]}, {:elixir_xdr, "~> 0.2.0", [hex: :elixir_xdr, repo: "hexpm", optional: false]}], "hexpm", "e43b0213a459b0f6013ac3fae42cf41c5beddd8cea861ac0963b2dbbac4ad85b"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }


### PR DESCRIPTION
We need to upgrade the stellar_base dependency to the `v0.8.7` version in order to have the latest changes and bug fixes.

And since the scorecard workflow [failed](https://github.com/kommitters/stellar_base/actions/runs/3364710697/jobs/5579371353), we need to bump `ossf/scorecard-action` to v2.0.6

> Context: https://github.com/ossf/scorecard-action/issues/997