### PR TITLE
Update build badge and lock to ubuntu-20.04

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish:
     name: Publish Release to HEX PM
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         otp: ['23.3']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   tests:
     name: Run tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         otp: ['22.3', '23.3']
@@ -46,7 +46,7 @@ jobs:
 
   finish:
     needs: tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Set BUILD_NUMBER for Pull Request event
         if: github.event_name == 'pull_request'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Elixir Stellar SDK
-![Build Badge](https://img.shields.io/github/workflow/status/kommitters/stellar_sdk/StellarSDK%20CI/main?style=for-the-badge)
+![Build Badge](https://img.shields.io/github/actions/workflow/status/kommitters/stellar_sdk/ci.yml?branch=main&style=for-the-badge)
 [![Coverage Status](https://img.shields.io/coveralls/github/kommitters/stellar_sdk?style=for-the-badge)](https://coveralls.io/github/kommitters/stellar_sdk)
 [![Version Badge](https://img.shields.io/hexpm/v/stellar_sdk?style=for-the-badge)](https://hexdocs.pm/stellar_sdk)
 ![Downloads Badge](https://img.shields.io/hexpm/dt/stellar_sdk?style=for-the-badge)


### PR DESCRIPTION
The build badge URL needs to be updated. See https://github.com/badges/shields/issues/8671 for context.

Also, lock ubuntu version to ubuntu-20.04: https://github.com/erlef/setup-beam/issues/161#issuecomment-1336129218.