### PR TITLE
Fix SCAddress contract type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.15.1 (13.06.2023)
+
+* Fix `SCAddress` contract type.
+
 ## 0.15.0 (05.06.2023)
 * Add Soroban Preview 9 support.
 * Add Soroban examples.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The **Stellar SDK** is composed of two complementary components: **`TxBuild`** +
 ```elixir
 def deps do
   [
-    {:stellar_sdk, "~> 0.15.0"}
+    {:stellar_sdk, "~> 0.15.1"}
   ]
 end
 ```

--- a/lib/tx_build/sc_address.ex
+++ b/lib/tx_build/sc_address.ex
@@ -49,9 +49,10 @@ defmodule Stellar.TxBuild.SCAddress do
   end
 
   def to_xdr(%__MODULE__{type: :contract, value: value}) do
-    type = SCAddressType.new(:SC_ADDRESS_contract)
+    type = SCAddressType.new(:SC_ADDRESS_TYPE_CONTRACT)
 
     value
+    |> KeyPair.raw_contract()
     |> Hash.new()
     |> SCAddress.new(type)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Stellar.MixProject do
   use Mix.Project
 
   @github_url "https://github.com/kommitters/stellar_sdk"
-  @version "0.15.0"
+  @version "0.15.1"
 
   def project do
     [

--- a/test/tx_build/sc_address_test.exs
+++ b/test/tx_build/sc_address_test.exs
@@ -53,8 +53,12 @@ defmodule Stellar.TxBuild.SCAddressTest do
 
   test "to_xdr when type is contract", %{contract: contract} do
     %SCAddress{
-      sc_address: %Hash{value: "CCEMOFO5TE7FGOAJOA3RDHPC6RW3CFXRVIGOFQPFE4ZGOKA2QEA636SN"},
-      type: %SCAddressType{identifier: :SC_ADDRESS_contract}
+      sc_address: %Hash{
+        value:
+          <<136, 199, 21, 221, 153, 62, 83, 56, 9, 112, 55, 17, 157, 226, 244, 109, 177, 22, 241,
+            170, 12, 226, 193, 229, 39, 50, 103, 40, 26, 129, 1, 237>>
+      },
+      type: %SCAddressType{identifier: :SC_ADDRESS_TYPE_CONTRACT}
     } = contract |> TxSCAddress.new() |> TxSCAddress.to_xdr()
   end
 end


### PR DESCRIPTION
## Description
Fix SCAddress contract type, now it can be built correctly in XDR.
Closes #305 


### Before
```elixir
"CCEMOFO5TE7FGOAJOA3RDHPC6RW3CFXRVIGOFQPFE4ZGOKA2QEA636SN"
|> Stellar.TxBuild.SCAddress.new()
|> Stellar.TxBuild.SCAddress.to_xdr()
|> StellarBase.XDR.SCAddress.encode_xdr()

** (XDR.EnumError) The key which you try to encode doesn't belong to the current declarations
    (elixir_xdr 0.3.9) lib/xdr/enum.ex:49: XDR.Enum.encode_xdr!/1
    (elixir_xdr 0.3.9) lib/xdr/union.ex:39: XDR.Union.encode_xdr/1
```


### Now
```elixir
"CCEMOFO5TE7FGOAJOA3RDHPC6RW3CFXRVIGOFQPFE4ZGOKA2QEA636SN"
|> Stellar.TxBuild.SCAddress.new()
|> Stellar.TxBuild.SCAddress.to_xdr()
|> StellarBase.XDR.SCAddress.encode_xdr()

{:ok,
 <<0, 0, 0, 1, 136, 199, 21, 221, 153, 62, 83, 56, 9, 112, 55, 17, 157, 226,
   244, 109, 177, 22, 241, 170, 12, 226, 193, 229, 39, 50, 103, 40, 26, 129, 1,
   237>>}
```



