### PR TITLE
Update allowed endpoints due to scorecard upgrade

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -31,10 +31,10 @@ jobs:
             api.osv.dev:443
             api.securityscorecards.dev:443
             bestpractices.coreinfrastructure.org:443
-            fulcio.sigstore.dev:443
+            *.sigstore.dev:443
             github.com:443
-            rekor.sigstore.dev:443
             sigstore-tuf-root.storage.googleapis.com:443
+            oss-fuzz-build-logs.storage.googleapis.com:443
 
       - name: "Checkout code"
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3


### PR DESCRIPTION
In the most recent release, dependencies were updated including `ossf/scorecard-action`. However, the scorecard workflow failed because, as a result of the update, requests were made to endpoints that were not on the allowed list.

- See https://github.com/kommitters/stellar_sdk/actions/runs/5685762497
- See https://app.stepsecurity.io/github/kommitters/stellar_sdk/actions/runs/5685762497