### PR TITLE
[Horizon] Dynamic network configuration: Create `Stellar.Horizon.Server` struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,6 @@ end
 ```
 
 ## Configuration
-```elixir
-config :stellar_sdk, network: :test # Default is `:test`. To use the public network, set it to `:public`
-
-```
 
 The default HTTP Client is `:hackney`. Options to `:hackney` can be passed through configuration params.
 ```elixir
@@ -154,7 +150,11 @@ Each transaction has a [sequence number][stellar-docs-sequence-number] associate
 source_account = Stellar.TxBuild.Account.new("GDC3W2X5KUTZRTQIKXM5D2I5WG5JYSEJQWEELVPQ5YMWZR6CA2JJ35RW")
 
 # fetch next account's sequence number from Horizon
-{:ok, seq_num} = Stellar.Horizon.Accounts.fetch_next_sequence_number("GDC3W2X5KUTZRTQIKXM5D2I5WG5JYSEJQWEELVPQ5YMWZR6CA2JJ35RW")
+{:ok, seq_num} =
+  Stellar.Horizon.Accounts.fetch_next_sequence_number(
+    Stellar.Horizon.Server.testnet(),
+    "GDC3W2X5KUTZRTQIKXM5D2I5WG5JYSEJQWEELVPQ5YMWZR6CA2JJ35RW"
+  )
 
 # set the sequence number
 sequence_number = Stellar.TxBuild.SequenceNumber.new(seq_num)
@@ -436,6 +436,28 @@ More examples can be found in the [**tests**][sdk-tests].
 ## Querying Horizon
 Horizon is an API for interacting with the Stellar network.
 
+To query Horizon, you need to specify the Horizon server to use.
+
+```elixir
+# public horizon server
+Stellar.Horizon.Server.public()
+
+# testnet horizon server
+Stellar.Horizon.Server.testnet()
+
+# futurenet horizon server
+Stellar.Horizon.Server.futurenet()
+
+# local horizon server
+Stellar.Horizon.Server.local()
+
+# custom horizon server
+Stellar.Horizon.Server.new("https://horizon-standalone.com")
+```
+
+See [**Stellar.Horizon.Server**](https://hexdocs.pm/stellar_sdk/Stellar.Horizon.Server.html) for more details.
+
+
 To make it possible to explore the millions of records for resources like transactions and operations, this library paginates the data it returns for collection-based resources. Each individual transaction, operation, ledger, etc. is returned as a record.
 
 ```elixir
@@ -446,7 +468,7 @@ To make it possible to explore the millions of records for resources like transa
    failed_transaction_count: 0,
    fee_pool: 3.0e-5,
    ...
- }} = Ledgers.retrieve(1234)
+ }} = Ledgers.retrieve(Stellar.Horizon.Server.testnet(), 1234)
 ```
 
 A group of records is called a **collection**, records are returned as a list in the [**Stellar.Horizon.Collection**](https://hexdocs.pm/stellar_sdk/Stellar.Horizon.Collection.html#content) structure. To move between pages of a collection of records, use the `next` and `prev` attributes.
@@ -462,7 +484,7 @@ A group of records is called a **collection**, records are returned as a list in
      %Stellar.Horizon.Ledger{...},
      %Stellar.Horizon.Ledger{...}
    ]
- }} = Stellar.Horizon.Ledgers.all()
+ }} = Stellar.Horizon.Ledgers.all(Stellar.Horizon.Server.testnet())
 ```
 
 ### Pagination
@@ -474,7 +496,7 @@ The [HAL format links](https://developers.stellar.org/api/introduction/response-
    next: paginate_next_fn,
    prev: paginate_prev_fn,
    records: [...]
- }} = Stellar.Horizon.Transactions.all()
+ }} = Stellar.Horizon.Transactions.all(Stellar.Horizon.Server.testnet())
 
 # next page records for the collection
 paginate_next_fn.()
@@ -500,28 +522,57 @@ paginate_prev_fn.()
 ### Accounts
 ```elixir
 # retrieve an account
-Stellar.Horizon.Accounts.retrieve("GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD")
+Stellar.Horizon.Accounts.retrieve(
+  Stellar.Horizon.Server.testnet(),
+  "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD"
+)
 
 # fetch the ledger's sequence number for the account
-Stellar.Horizon.Accounts.fetch_next_sequence_number("GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD")
+Stellar.Horizon.Accounts.fetch_next_sequence_number(
+  Stellar.Horizon.Server.testnet(),
+  "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD"
+)
 
 # list accounts
-Stellar.Horizon.Accounts.all(limit: 10, order: :asc)
+Stellar.Horizon.Accounts.all(
+  Stellar.Horizon.Server.testnet(),
+  limit: 10,
+  order: :asc
+)
 
 # list accounts by sponsor
-Stellar.Horizon.Accounts.all(sponsor: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD")
+Stellar.Horizon.Accounts.all(
+  Stellar.Horizon.Server.testnet(),
+  sponsor: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD"
+)
 
 # list accounts by signer
-Stellar.Horizon.Accounts.all(signer: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", order: :desc)
+Stellar.Horizon.Accounts.all(
+  Stellar.Horizon.Server.testnet(),
+  signer: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD",
+  order: :desc
+)
 
 # list accounts by canonical asset address
-Stellar.Horizon.Accounts.all(asset: "TEST:GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", limit: 20)
+Stellar.Horizon.Accounts.all(
+  Stellar.Horizon.Server.testnet(),
+  asset: "TEST:GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD",
+  limit: 20
+)
 
 # list account's transactions
-Stellar.Horizon.Accounts.list_transactions("GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", limit: 20)
+Stellar.Horizon.Accounts.list_transactions(
+  Stellar.Horizon.Server.testnet(),
+  "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD",
+  limit: 20
+)
 
 # list account's payments
-Stellar.Horizon.Accounts.list_payments("GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", limit: 20)
+Stellar.Horizon.Accounts.list_payments(
+  Stellar.Horizon.Server.testnet(),
+  "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD",
+  limit: 20
+)
 ```
 
 See [**Stellar.Horizon.Accounts**](https://hexdocs.pm/stellar_sdk/Stellar.Horizon.Accounts.html#content) for more details.
@@ -529,25 +580,37 @@ See [**Stellar.Horizon.Accounts**](https://hexdocs.pm/stellar_sdk/Stellar.Horizo
 ### Transactions
 ```elixir
 # submit a transaction
-Stellar.Horizon.Transactions.create(base64_tx_envelope)
+Stellar.Horizon.Transactions.create(Stellar.Horizon.Server.testnet(), base64_tx_envelope)
 
 # retrieve a transaction
-Stellar.Horizon.Transactions.retrieve("5ebd5c0af4385500b53dd63b0ef5f6e8feef1a7e1c86989be3cdcce825f3c0cc")
+Stellar.Horizon.Transactions.retrieve(Stellar.Horizon.Server.testnet(), "5ebd5c0af4385500b53dd63b0ef5f6e8feef1a7e1c86989be3cdcce825f3c0cc")
 
 # list transactions
-Stellar.Horizon.Transactions.all(limit: 10, order: :asc)
+Stellar.Horizon.Transactions.all(Stellar.Horizon.Server.testnet(), limit: 10, order: :asc)
 
 # include failed transactions
-Stellar.Horizon.Transactions.all(limit: 10, include_failed: true)
+Stellar.Horizon.Transactions.all(Stellar.Horizon.Server.testnet(), limit: 10, include_failed: true)
 
 # list transaction's effects
-Stellar.Horizon.Transactions.list_effects("6b983a4e0dc3c04f4bd6b9037c55f70a09c434dfd01492be1077cf7ea68c2e4a", limit: 20)
+Stellar.Horizon.Transactions.list_effects(
+  Stellar.Horizon.Server.testnet(),
+  "6b983a4e0dc3c04f4bd6b9037c55f70a09c434dfd01492be1077cf7ea68c2e4a",
+  limit: 20
+)
 
 # list transaction's operations
-Stellar.Horizon.Transactions.list_operations("6b983a4e0dc3c04f4bd6b9037c55f70a09c434dfd01492be1077cf7ea68c2e4a", limit: 20)
+Stellar.Horizon.Transactions.list_operations(
+  Stellar.Horizon.Server.testnet(),
+  "6b983a4e0dc3c04f4bd6b9037c55f70a09c434dfd01492be1077cf7ea68c2e4a",
+  limit: 20
+)
 
 # join transactions in the operations response
-Stellar.Horizon.Transactions.list_operations("6b983a4e0dc3c04f4bd6b9037c55f70a09c434dfd01492be1077cf7ea68c2e4a", join: "transactions")
+Stellar.Horizon.Transactions.list_operations(
+  Stellar.Horizon.Server.testnet(),
+  "6b983a4e0dc3c04f4bd6b9037c55f70a09c434dfd01492be1077cf7ea68c2e4a",
+  join: "transactions"
+)
 ```
 
 See [**Stellar.Horizon.Transactions**](https://hexdocs.pm/stellar_sdk/Stellar.Horizon.Transactions.html#content) for more details.
@@ -556,22 +619,22 @@ See [**Stellar.Horizon.Transactions**](https://hexdocs.pm/stellar_sdk/Stellar.Ho
 ### Operations
 ```elixir
 # retrieve an operation
-Stellar.Horizon.Operations.retrieve(121693057904021505)
+Stellar.Horizon.Operations.retrieve(Stellar.Horizon.Server.testnet(), 121693057904021505)
 
 # list operations
-Stellar.Horizon.Operations.all(limit: 10, order: :asc)
+Stellar.Horizon.Operations.all(Stellar.Horizon.Server.testnet(), limit: 10, order: :asc)
 
 # include failed operations
-Stellar.Horizon.Operations.all(limit: 10, include_failed: true)
+Stellar.Horizon.Operations.all(Stellar.Horizon.Server.testnet(), limit: 10, include_failed: true)
 
 # include operation's transactions
-Stellar.Horizon.Operations.all(limit: 10, join: "transactions")
+Stellar.Horizon.Operations.all(Stellar.Horizon.Server.testnet(), limit: 10, join: "transactions")
 
 # list operation's payments
-Stellar.Horizon.Operations.list_payments(limit: 20)
+Stellar.Horizon.Operations.list_payments(Stellar.Horizon.Server.testnet(), limit: 20)
 
 # list operation's effects
-Stellar.Horizon.Operations.list_effects(121693057904021505, limit: 20)
+Stellar.Horizon.Operations.list_effects(Stellar.Horizon.Server.testnet(), 121693057904021505, limit: 20)
 ```
 
 See [**Stellar.Horizon.Operations**](https://hexdocs.pm/stellar_sdk/Stellar.Horizon.Operations.html#content) for more details.
@@ -580,18 +643,24 @@ See [**Stellar.Horizon.Operations**](https://hexdocs.pm/stellar_sdk/Stellar.Hori
 ### Assets
 ```elixir
 # list ledger's assets
-Stellar.Horizon.Assets.all(limit: 20, order: :desc)
+Stellar.Horizon.Assets.all(Stellar.Horizon.Server.testnet(), limit: 20, order: :desc)
 
 # list assets by asset issuer
-Stellar.Horizon.Assets.all(asset_issuer: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD")
+Stellar.Horizon.Assets.all(Stellar.Horizon.Server.testnet(), asset_issuer: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD")
 
 # list assets by asset code
-Stellar.Horizon.Assets.list_by_asset_code("TEST")
-Stellar.Horizon.Assets.all(asset_code: "TEST")
+Stellar.Horizon.Assets.list_by_asset_code(Stellar.Horizon.Server.testnet(), "TEST")
+Stellar.Horizon.Assets.all(Stellar.Horizon.Server.testnet(), asset_code: "TEST")
 
 # list assets by asset issuer
-Stellar.Horizon.Assets.all(asset_issuer: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD")
-Stellar.Horizon.Assets.list_by_asset_issuer("GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD")
+Stellar.Horizon.Assets.all(
+  Stellar.Horizon.Server.testnet(),
+  asset_issuer: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD"
+)
+Stellar.Horizon.Assets.list_by_asset_issuer(
+  Stellar.Horizon.Server.testnet(),
+  "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD"
+)
 ```
 
 See [**Stellar.Horizon.Assets**](https://hexdocs.pm/stellar_sdk/Stellar.Horizon.Assets.html#content) for more details.
@@ -600,22 +669,22 @@ See [**Stellar.Horizon.Assets**](https://hexdocs.pm/stellar_sdk/Stellar.Horizon.
 ### Ledgers
 ```elixir
 # retrieve a ledger
-Stellar.Horizon.Ledgers.retrieve(27147222)
+Stellar.Horizon.Ledgers.retrieve(Stellar.Horizon.Server.testnet(), 27147222)
 
 # list ledgers
-Stellar.Horizon.Ledgers.all(limit: 10, order: :asc)
+Stellar.Horizon.Ledgers.all(Stellar.Horizon.Server.testnet(), limit: 10, order: :asc)
 
 # list ledger's transactions
-Stellar.Horizon.Ledgers.list_transactions(27147222, limit: 20)
+Stellar.Horizon.Ledgers.list_transactions(Stellar.Horizon.Server.testnet(), 27147222, limit: 20)
 
 # list ledger's operations
-Stellar.Horizon.Ledgers.list_operations(27147222, join: "transactions")
+Stellar.Horizon.Ledgers.list_operations(Stellar.Horizon.Server.testnet(), 27147222, join: "transactions")
 
 # list ledger's payments including failed transactions
-Stellar.Horizon.Ledgers.list_payments(27147222, include_failed: true)
+Stellar.Horizon.Ledgers.list_payments(Stellar.Horizon.Server.testnet(), 27147222, include_failed: true)
 
 # list ledger's effects
-Stellar.Horizon.Ledgers.list_effects(27147222, limit: 20)
+Stellar.Horizon.Ledgers.list_effects(Stellar.Horizon.Server.testnet(), 27147222, limit: 20)
 ```
 
 See [**Stellar.Horizon.Ledgers**](https://hexdocs.pm/stellar_sdk/Stellar.Horizon.Ledgers.html#content) for more details.
@@ -624,16 +693,24 @@ See [**Stellar.Horizon.Ledgers**](https://hexdocs.pm/stellar_sdk/Stellar.Horizon
 ### Offers
 ```elixir
 # list offers
-Stellar.Horizon.Offers.all(limit: 20, order: :asc)
+Stellar.Horizon.Offers.all(Stellar.Horizon.Server.testnet(), limit: 20, order: :asc)
 
 # list offers by sponsor
-Stellar.Horizon.Offers.all(sponsor: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD")
+Stellar.Horizon.Offers.all(
+  Stellar.Horizon.Server.testnet(),
+  sponsor: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD"
+)
 
 # list offers by seller
-Stellar.Horizon.Offers.all(seller: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", order: :desc)
+Stellar.Horizon.Offers.all(
+  Stellar.Horizon.Server.testnet(),
+  seller: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD",
+  order: :desc
+)
 
 # list offers by selling_asset
 Stellar.Horizon.Offers.all(
+  Stellar.Horizon.Server.testnet(),
   selling_asset: [
     code: "TEST",
     issuer: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD"
@@ -642,6 +719,7 @@ Stellar.Horizon.Offers.all(
 
 # list offers by buying_asset
 Stellar.Horizon.Offers.all(
+  Stellar.Horizon.Server.testnet(),
   buying_asset: [
     code: "TEST",
     issuer: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD"
@@ -650,6 +728,7 @@ Stellar.Horizon.Offers.all(
 
 # list offers by selling_asset and buying_asset
 Stellar.Horizon.Trades.all(
+  Stellar.Horizon.Server.testnet(),
   selling_asset: [
     code: "TEST",
     issuer: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD"
@@ -661,6 +740,7 @@ Stellar.Horizon.Trades.all(
 )
 
 Stellar.Horizon.Offers.all(
+  Stellar.Horizon.Server.testnet(),
   selling_asset: [
     code: "TEST",
     issuer: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD"
@@ -669,7 +749,7 @@ Stellar.Horizon.Offers.all(
 )
 
 # list offer's trades
-Stellar.Horizon.Offers.list_trades(165563085, limit: 20)
+Stellar.Horizon.Offers.list_trades(Stellar.Horizon.Server.testnet(), 165563085, limit: 20)
 ```
 
 See [**Stellar.Horizon.Offers**](https://hexdocs.pm/stellar_sdk/Stellar.Horizon.Offers.html#content) for more details.
@@ -678,13 +758,14 @@ See [**Stellar.Horizon.Offers**](https://hexdocs.pm/stellar_sdk/Stellar.Horizon.
 ### Trades
 ```elixir
 # list tardes
-Stellar.Horizon.Trades.all(limit: 20, order: :asc)
+Stellar.Horizon.Trades.all(Stellar.Horizon.Server.testnet(), limit: 20, order: :asc)
 
 # list trades by offer_id
-Stellar.Horizon.Trades.all(offer_id: 165563085)
+Stellar.Horizon.Trades.all(Stellar.Horizon.Server.testnet(), offer_id: 165563085)
 
 # list trades by specific orderbook
 Stellar.Horizon.Trades.all(
+  Stellar.Horizon.Server.testnet(),
   base_asset: [
     code: "TEST",
     issuer: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD"
@@ -696,7 +777,8 @@ Stellar.Horizon.Trades.all(
 )
 
 Stellar.Horizon.Trades.all(
-    base_asset: [
+  Stellar.Horizon.Server.testnet(),
+  base_asset: [
     code: "TEST",
     issuer: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD"
   ],
@@ -704,7 +786,7 @@ Stellar.Horizon.Trades.all(
 )
 
 # list trades by trade_type
-Stellar.Horizon.Trades.all(trade_type: "liquidity_pools", limit: 20)
+Stellar.Horizon.Trades.all(Stellar.Horizon.Server.testnet(), trade_type: "liquidity_pools", limit: 20)
 ```
 
 See [**Stellar.Horizon.Trades**](https://hexdocs.pm/stellar_sdk/Stellar.Horizon.Trades.html#content) for more details.
@@ -713,31 +795,66 @@ See [**Stellar.Horizon.Trades**](https://hexdocs.pm/stellar_sdk/Stellar.Horizon.
 ### ClaimableBalances
 ```elixir
 # retrieve a claimable balance
-Stellar.Horizon.ClaimableBalances.retrieve("00000000ca6aba5fb0993844e0076f75bee53f2b8014be29cd8f2e6ae19fb0a17fc68695")
+Stellar.Horizon.ClaimableBalances.retrieve(
+  Stellar.Horizon.Server.testnet(),
+  "00000000ca6aba5fb0993844e0076f75bee53f2b8014be29cd8f2e6ae19fb0a17fc68695"
+)
 
 # list claimable balances
-Stellar.Horizon.ClaimableBalances.all(limit: 2, order: :asc)
+Stellar.Horizon.ClaimableBalances.all(Stellar.Horizon.Server.testnet(), limit: 2, order: :asc)
 
 # list claimable balances by sponsor
-Stellar.Horizon.ClaimableBalances.list_by_sponsor("GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD")
-Stellar.Horizon.ClaimableBalances.all(sponsor: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD")
+Stellar.Horizon.ClaimableBalances.list_by_sponsor(
+  Stellar.Horizon.Server.testnet(),
+  "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD"
+)
+Stellar.Horizon.ClaimableBalances.all(
+  Stellar.Horizon.Server.testnet(),
+  sponsor: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD"
+)
 
 # list claimable balances by claimant
-Stellar.Horizon.ClaimableBalances.list_by_claimant("GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD")
-Stellar.Horizon.ClaimableBalances.all(claimant: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", order: :desc)
+Stellar.Horizon.ClaimableBalances.list_by_claimant(
+  Stellar.Horizon.Server.testnet(),
+  "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD"
+)
+Stellar.Horizon.ClaimableBalances.all(
+  Stellar.Horizon.Server.testnet(),
+  claimant: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD",
+  order: :desc
+)
 
 # list claimable balances by canonical asset address
-Stellar.Horizon.ClaimableBalances.list_by_asset("TEST:GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD")
-Stellar.Horizon.ClaimableBalances.all(asset: "TEST:GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", limit: 20)
+Stellar.Horizon.ClaimableBalances.list_by_asset(
+  Stellar.Horizon.Server.testnet(),
+  "TEST:GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD"
+)
+Stellar.Horizon.ClaimableBalances.all(
+  Stellar.Horizon.Server.testnet(),
+  asset: "TEST:GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD",
+  limit: 20
+)
 
 # list claimable balance's transactions
-Stellar.Horizon.ClaimableBalances.list_transactions("00000000ca6aba5fb0993844e0076f75bee53f2b8014be29cd8f2e6ae19fb0a17fc68695", limit: 20)
+Stellar.Horizon.ClaimableBalances.list_transactions(
+  Stellar.Horizon.Server.testnet(),
+  "00000000ca6aba5fb0993844e0076f75bee53f2b8014be29cd8f2e6ae19fb0a17fc68695",
+  limit: 20
+)
 
 # list claimable balance's operations
-Stellar.Horizon.ClaimableBalances.list_operations("00000000ca6aba5fb0993844e0076f75bee53f2b8014be29cd8f2e6ae19fb0a17fc68695", limit: 20)
+Stellar.Horizon.ClaimableBalances.list_operations(
+  Stellar.Horizon.Server.testnet(),
+  "00000000ca6aba5fb0993844e0076f75bee53f2b8014be29cd8f2e6ae19fb0a17fc68695",
+  limit: 20
+)
 
 # join transactions in the operations response
-Stellar.Horizon.ClaimableBalances.list_operations("00000000ca6aba5fb0993844e0076f75bee53f2b8014be29cd8f2e6ae19fb0a17fc68695", join: "transactions")
+Stellar.Horizon.ClaimableBalances.list_operations(
+  Stellar.Horizon.Server.testnet(),
+  "00000000ca6aba5fb0993844e0076f75bee53f2b8014be29cd8f2e6ae19fb0a17fc68695",
+  join: "transactions"
+)
 ```
 
 See [**Stellar.Horizon.Balances**](https://hexdocs.pm/stellar_sdk/Stellar.Horizon.ClaimableBalances.html#content) for more details.
@@ -746,28 +863,54 @@ See [**Stellar.Horizon.Balances**](https://hexdocs.pm/stellar_sdk/Stellar.Horizo
 ### LiquidityPools
 ```elixir
 # retrieve a liquidity pool
-Stellar.Horizon.LiquidityPools.retrieve("001365fc79ca661f31ba3ee0849ae4ba36f5c377243242d37fad5b1bb8912dbc")
+Stellar.Horizon.LiquidityPools.retrieve(
+  Stellar.Horizon.Server.testnet(),
+  "001365fc79ca661f31ba3ee0849ae4ba36f5c377243242d37fad5b1bb8912dbc"
+)
 
 # list liquidity pools
-Stellar.Horizon.LiquidityPools.all(limit: 2, order: :asc)
+Stellar.Horizon.LiquidityPools.all(Stellar.Horizon.Server.testnet(), limit: 2, order: :asc)
 
 # list liquidity pools by reserves
-Stellar.Horizon.LiquidityPools.all(reserves: "TEST:GCXMW..., TEST2:GCXMW...")
+Stellar.Horizon.LiquidityPools.all(
+  Stellar.Horizon.Server.testnet(),
+  reserves: "TEST:GCXMW..., TEST2:GCXMW..."
+)
 
 # list liquidity pools by account
-Stellar.Horizon.LiquidityPools.all(account: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", order: :desc)
+Stellar.Horizon.LiquidityPools.all(
+  Stellar.Horizon.Server.testnet(),
+  account: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD",
+  order: :desc
+)
 
 # list liquidity pool's effects
-Stellar.Horizon.LiquidityPools.list_effects("001365fc79ca661f31ba3ee0849ae4ba36f5c377243242d37fad5b1bb8912dbc", limit: 20)
+Stellar.Horizon.LiquidityPools.list_effects(
+  Stellar.Horizon.Server.testnet(),
+  "001365fc79ca661f31ba3ee0849ae4ba36f5c377243242d37fad5b1bb8912dbc",
+  limit: 20
+)
 
 # list liquidity pool's trades
-Stellar.Horizon.LiquidityPools.list_trades("001365fc79ca661f31ba3ee0849ae4ba36f5c377243242d37fad5b1bb8912dbc", limit: 20)
+Stellar.Horizon.LiquidityPools.list_trades(
+  Stellar.Horizon.Server.testnet(),
+  "001365fc79ca661f31ba3ee0849ae4ba36f5c377243242d37fad5b1bb8912dbc",
+  limit: 20
+)
 
 # list liquidity pool's transactions
-Stellar.Horizon.LiquidityPools.list_transactions("001365fc79ca661f31ba3ee0849ae4ba36f5c377243242d37fad5b1bb8912dbc", limit: 20)
+Stellar.Horizon.LiquidityPools.list_transactions(
+  Stellar.Horizon.Server.testnet(),
+  "001365fc79ca661f31ba3ee0849ae4ba36f5c377243242d37fad5b1bb8912dbc",
+  limit: 20
+)
 
 # list liquidity pool's operations
-Stellar.Horizon.LiquidityPools.list_operations("001365fc79ca661f31ba3ee0849ae4ba36f5c377243242d37fad5b1bb8912dbc", limit: 20)
+Stellar.Horizon.LiquidityPools.list_operations(
+  Stellar.Horizon.Server.testnet(),
+  "001365fc79ca661f31ba3ee0849ae4ba36f5c377243242d37fad5b1bb8912dbc",
+  limit: 20
+)
 ```
 
 See [**Stellar.Horizon.Pools**](https://hexdocs.pm/stellar_sdk/Stellar.Horizon.LiquidityPools.html#content) for more details.
@@ -776,7 +919,11 @@ See [**Stellar.Horizon.Pools**](https://hexdocs.pm/stellar_sdk/Stellar.Horizon.L
 ### Effects
 ```elixir
 # list effects
-Stellar.Horizon.Effects.all(limit: 10, order: :asc)
+Stellar.Horizon.Effects.all(
+  Stellar.Horizon.Server.testnet(),
+  limit: 10,
+  order: :asc
+)
 ```
 
 See [**Stellar.Horizon.Effects**](https://hexdocs.pm/stellar_sdk/Stellar.Horizon.Effects.html#content) for more details.
@@ -784,7 +931,7 @@ See [**Stellar.Horizon.Effects**](https://hexdocs.pm/stellar_sdk/Stellar.Horizon
 ### FeeStats
 ```elixir
 # retrieve fee stats
-Stellar.Horizon.FeeStats.retrieve()
+Stellar.Horizon.FeeStats.retrieve(Stellar.Horizon.Server.testnet())
 ```
 
 See [**Stellar.Horizon.FeeStats**](https://developers.stellar.org/api/aggregations/fee-stats/single/) for more details.
@@ -799,7 +946,12 @@ This will return information about potential path payments:
 - [Optional] destination_account. The Stellar address of the reciever.
 
 ```elixir
-Stellar.Horizon.PaymentPaths.list_paths(source_account: "GBRSLTT74SKP62KJ7ENTMP5V4R7UGB6E5UQESNIIRWUNRCCUO4ZMFM4C", destination_asset: :native, destination_amount: 5)
+Stellar.Horizon.PaymentPaths.list_paths(
+  Stellar.Horizon.Server.testnet(),
+  source_account: "GBRSLTT74SKP62KJ7ENTMP5V4R7UGB6E5UQESNIIRWUNRCCUO4ZMFM4C",
+  destination_asset: :native,
+  destination_amount: 5
+)
 ```
 
 #### List strict receive payment paths
@@ -809,7 +961,12 @@ Stellar.Horizon.PaymentPaths.list_paths(source_account: "GBRSLTT74SKP62KJ7ENTMP5
 - [Optional] source_assets. A comma-separated list of assets available to the sender.
 
 ```elixir
-Stellar.Horizon.PaymentPaths.list_receive_paths(destination_asset: :native, destination_amount: 5, source_account: "GBTKSXOTFMC5HR25SNL76MOVQW7GA3F6CQEY622ASLUV4VMLITI6TCOO")
+Stellar.Horizon.PaymentPaths.list_receive_paths(
+  Stellar.Horizon.Server.testnet(),
+  destination_asset: :native,
+  destination_amount: 5,
+  source_account: "GBTKSXOTFMC5HR25SNL76MOVQW7GA3F6CQEY622ASLUV4VMLITI6TCOO"
+)
 ```
 
 #### List strict send payment paths
@@ -819,7 +976,12 @@ Stellar.Horizon.PaymentPaths.list_receive_paths(destination_asset: :native, dest
 - [Optional] destination_assets. A comma-separated list of assets that the recipient can receive.
 
 ```elixir
-Stellar.Horizon.PaymentPaths.list_send_paths(source_asset: :native, source_amount: 5, destination_assets: "TEST:GA654JC6QLA3ZH4O5V7X5NPM7KEWHKRG5GJA4PETK4SOFBUJLCCN74KQ")
+Stellar.Horizon.PaymentPaths.list_send_paths(
+  Stellar.Horizon.Server.testnet(),
+  source_asset: :native,
+  source_amount: 5,
+  destination_assets: "TEST:GA654JC6QLA3ZH4O5V7X5NPM7KEWHKRG5GJA4PETK4SOFBUJLCCN74KQ"
+)
 ```
 
 See [**Stellar.Horizon.Paths**](https://developers.stellar.org/api/aggregations/paths/) for more details.
@@ -833,14 +995,21 @@ Provides an order book’s bids and asks:
 - [Optional] limit. The maximum number of records returned
 
 ```elixir
-Stellar.Horizon.OrderBooks.retrieve(selling_asset: :native, buying_asset: :native)
-Stellar.Horizon.OrderBooks.retrieve(selling_asset: :native,
-                                    buying_asset: [
-                                      code: "BB1",
-                                      issuer: "GD5J6HLF5666X4AZLTFTXLY46J5SW7EXRKBLEYPJP33S33MXZGV6CWFN"
-                                    ],
-                                    limit: 2
-                                    )
+Stellar.Horizon.OrderBooks.retrieve(
+  Stellar.Horizon.Server.testnet(),
+  selling_asset: :native,
+  buying_asset: :native
+)
+
+Stellar.Horizon.OrderBooks.retrieve(
+  Stellar.Horizon.Server.testnet(),
+  selling_asset: :native,
+  buying_asset: [
+    code: "BB1",
+    issuer: "GD5J6HLF5666X4AZLTFTXLY46J5SW7EXRKBLEYPJP33S33MXZGV6CWFN"
+  ],
+  limit: 2
+)
 ```
 
 See [**Stellar.Horizon.OrderBooks**](https://developers.stellar.org/api/aggregations/order-books/) for more details.
@@ -859,17 +1028,24 @@ Displays trade data based on filters set in the arguments:
 - [Optional] limit. The maximum number of records returned.
 
 ```elixir
-Stellar.Horizon.TradeAggregations.list_trade_aggregations(base_asset: :native, counter_asset: :native, resolution: "60000")
-Stellar.Horizon.TradeAggregations.list_trade_aggregations(base_asset: :native,
-                                                         counter_asset: [
-                                                           code: "EURT",
-                                                           issuer: "GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S"
-                                                         ],
-                                                         resolution: "3600000",
-                                                         start_time: "1582156800000",
-                                                         end_time: "1582178400000"
-                                                        )
+Stellar.Horizon.TradeAggregations.list_trade_aggregations(
+  Stellar.Horizon.Server.testnet(),
+  base_asset: :native,
+  counter_asset: :native,
+  resolution: "60000"
+)
 
+Stellar.Horizon.TradeAggregations.list_trade_aggregations(
+  Stellar.Horizon.Server.testnet(),
+  base_asset: :native,
+  counter_asset: [
+    code: "EURT",
+    issuer: "GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S"
+  ],
+  resolution: "3600000",
+  start_time: "1582156800000",
+  end_time: "1582178400000"
+)
 ```
 
 See [**Stellar.Horizon.TradeAggregations**](https://developers.stellar.org/api/aggregations/trade-aggregations/) for more details.

--- a/docs/examples/operations/create_account.md
+++ b/docs/examples/operations/create_account.md
@@ -5,7 +5,7 @@
 source_account = Stellar.TxBuild.Account.new("GDC3W2X5KUTZRTQIKXM5D2I5WG5JYSEJQWEELVPQ5YMWZR6CA2JJ35RW")
 
 # 2. set the next sequence number for the founder account
-{:ok, seq_num} = Stellar.Horizon.Accounts.fetch_next_sequence_number("GDC3W2X5KUTZRTQIKXM5D2I5WG5JYSEJQWEELVPQ5YMWZR6CA2JJ35RW")
+{:ok, seq_num} = Stellar.Horizon.Accounts.fetch_next_sequence_number(Stellar.Horizon.Server.testnet(), "GDC3W2X5KUTZRTQIKXM5D2I5WG5JYSEJQWEELVPQ5YMWZR6CA2JJ35RW")
 sequence_number = Stellar.TxBuild.SequenceNumber.new(seq_num)
 
 # 3. build the create_account operation
@@ -26,5 +26,5 @@ signature = Stellar.TxBuild.Signature.new(signer_key_pair)
   |> Stellar.TxBuild.sign(signature)
   |> Stellar.TxBuild.envelope()
 
-{:ok, submitted_tx} = Stellar.Horizon.Transactions.create(base64_envelope)
+{:ok, submitted_tx} = Stellar.Horizon.Transactions.create(Stellar.Horizon.Server.testnet(), base64_envelope)
 ```

--- a/docs/examples/operations/payments.md
+++ b/docs/examples/operations/payments.md
@@ -7,7 +7,8 @@
 source_account = Stellar.TxBuild.Account.new("GDC3W2X5KUTZRTQIKXM5D2I5WG5JYSEJQWEELVPQ5YMWZR6CA2JJ35RW")
 
 # 2. set the next sequence number for the payer account
-{:ok, seq_num} = Stellar.Horizon.Accounts.fetch_next_sequence_number("GDC3W2X5KUTZRTQIKXM5D2I5WG5JYSEJQWEELVPQ5YMWZR6CA2JJ35RW")
+server = Stellar.Horizon.Server.testnet()
+{:ok, seq_num} = Stellar.Horizon.Accounts.fetch_next_sequence_number(server, "GDC3W2X5KUTZRTQIKXM5D2I5WG5JYSEJQWEELVPQ5YMWZR6CA2JJ35RW")
 sequence_number = Stellar.TxBuild.SequenceNumber.new(seq_num)
 
 # 3. build the payment operation
@@ -29,7 +30,7 @@ signature = Stellar.TxBuild.Signature.new(signer_key_pair)
   |> Stellar.TxBuild.sign(signature)
   |> Stellar.TxBuild.envelope()
 
-{:ok, submitted_tx} = Stellar.Horizon.Transactions.create(base64_envelope)
+{:ok, submitted_tx} = Stellar.Horizon.Transactions.create(server, base64_envelope)
 ```
 
 ## Alphanum asset payment
@@ -39,7 +40,8 @@ signature = Stellar.TxBuild.Signature.new(signer_key_pair)
 source_account = Stellar.TxBuild.Account.new("GDC3W2X5KUTZRTQIKXM5D2I5WG5JYSEJQWEELVPQ5YMWZR6CA2JJ35RW")
 
 # 2. set the next sequence number for the payer account
-{:ok, seq_num} = Stellar.Horizon.Accounts.fetch_next_sequence_number("GDC3W2X5KUTZRTQIKXM5D2I5WG5JYSEJQWEELVPQ5YMWZR6CA2JJ35RW")
+server = Stellar.Horizon.Server.testnet()
+{:ok, seq_num} = Stellar.Horizon.Accounts.fetch_next_sequence_number(server, "GDC3W2X5KUTZRTQIKXM5D2I5WG5JYSEJQWEELVPQ5YMWZR6CA2JJ35RW")
 sequence_number = Stellar.TxBuild.SequenceNumber.new(seq_num)
 
 # 3. build the payment operation
@@ -61,5 +63,5 @@ signature = Stellar.TxBuild.Signature.new(signer_key_pair)
   |> Stellar.TxBuild.sign(signature)
   |> Stellar.TxBuild.envelope()
 
-{:ok, submitted_tx} = Stellar.Horizon.Transactions.create(base64_envelope)
+{:ok, submitted_tx} = Stellar.Horizon.Transactions.create(server, base64_envelope)
 ```

--- a/docs/examples/signatures/ed25519_signed_payload.md
+++ b/docs/examples/signatures/ed25519_signed_payload.md
@@ -69,7 +69,8 @@ So here, you use the `Stellar.TxBuild.SetOptions` operation to set the signer an
 source_account = Stellar.TxBuild.Account.new(payer_pk)
 
 # 2. set the next sequence number for the source account
-{:ok, seq_num} = Stellar.Horizon.Accounts.fetch_next_sequence_number(payer_pk)
+server = Stellar.Horizon.Server.testnet()
+{:ok, seq_num} = Stellar.Horizon.Accounts.fetch_next_sequence_number(server, payer_pk)
 sequence_number = Stellar.TxBuild.SequenceNumber.new(seq_num)
 
 # 3. build the set_options operation setting the ed25519 signed payload as a signer with weight 1
@@ -92,7 +93,7 @@ signature = Stellar.TxBuild.Signature.new(ed25519: payer_sk)
   |> Stellar.TxBuild.sign(signature)
   |> Stellar.TxBuild.envelope()
 
-{:ok, submitted_tx} = Stellar.Horizon.Transactions.create(envelope)
+{:ok, submitted_tx} = Stellar.Horizon.Transactions.create(server, envelope)
 ```
 
 ### 4. Send a payment using the Ed25519 Signed Payload signature
@@ -104,7 +105,8 @@ Once you have established the signer, you can use the `payload` and the secret k
 source_account = Stellar.TxBuild.Account.new(payer_pk)
 
 # 2. set the next sequence number for the founder account
-{:ok, seq_num} = Stellar.Horizon.Accounts.fetch_next_sequence_number(payer_pk)
+server = Stellar.Horizon.Server.testnet()
+{:ok, seq_num} = Stellar.Horizon.Accounts.fetch_next_sequence_number(server, payer_pk)
 sequence_number = Stellar.TxBuild.SequenceNumber.new(seq_num)
 
 # 3. build the payment operation
@@ -127,7 +129,7 @@ signature = Stellar.TxBuild.Signature.new(signed_payload: [payload: payload, ed2
   |> Stellar.TxBuild.sign(signature)
   |> Stellar.TxBuild.envelope()
 
-{:ok, submitted_tx} = Stellar.Horizon.Transactions.create(envelope)
+{:ok, submitted_tx} = Stellar.Horizon.Transactions.create(server, envelope)
 ```
 
 > 👍 That's it!

--- a/docs/examples/signatures/hash_x.md
+++ b/docs/examples/signatures/hash_x.md
@@ -63,7 +63,8 @@ Setting the signer is done via the `Stellar.TxBuild.SetOptions` operation, see t
 source_account = Stellar.TxBuild.Account.new(payer_pk)
 
 # 2. set the next sequence number for the source account
-{:ok, seq_num} = Stellar.Horizon.Accounts.fetch_next_sequence_number(payer_pk)
+server = Stellar.Horizon.Server.testnet()
+{:ok, seq_num} = Stellar.Horizon.Accounts.fetch_next_sequence_number(server, payer_pk)
 sequence_number = Stellar.TxBuild.SequenceNumber.new(seq_num)
 
 # 3. build the set_options operation setting the hash(x) as a signer with weight 1
@@ -80,7 +81,7 @@ signature = Stellar.TxBuild.Signature.new(ed25519: payer_sk)
   |> Stellar.TxBuild.sign(signature)
   |> Stellar.TxBuild.envelope()
 
-{:ok, submitted_tx} = Stellar.Horizon.Transactions.create(envelope)
+{:ok, submitted_tx} = Stellar.Horizon.Transactions.create(server, envelope)
 ```
 
 The transaction is submitted! Now, the `hash(x)` is a signer of the account.
@@ -96,7 +97,8 @@ Let's send a payment to the destination account!
 source_account = Stellar.TxBuild.Account.new(payer_pk)
 
 # 2. set the next sequence number for the founder account
-{:ok, seq_num} = Stellar.Horizon.Accounts.fetch_next_sequence_number(payer_pk)
+server = Stellar.Horizon.Server.testnet()
+{:ok, seq_num} = Stellar.Horizon.Accounts.fetch_next_sequence_number(server, payer_pk)
 sequence_number = Stellar.TxBuild.SequenceNumber.new(seq_num)
 
 # 3. build the payment operation
@@ -118,7 +120,7 @@ signature = Stellar.TxBuild.Signature.new(hash_x: preimage)
   |> Stellar.TxBuild.sign(signature)
   |> Stellar.TxBuild.envelope()
 
-{:ok, submitted_tx} = Stellar.Horizon.Transactions.create(envelope)
+{:ok, submitted_tx} = Stellar.Horizon.Transactions.create(server, envelope)
 ```
 
 > 👍 That's it!

--- a/docs/examples/signatures/pre_auth_tx.md
+++ b/docs/examples/signatures/pre_auth_tx.md
@@ -37,7 +37,8 @@ In order to create a pre-authorized transaction, you need to create a future tra
 source_account = Stellar.TxBuild.Account.new(public_key)
 
 # 2. set the next sequence number + 1 for the source account
-{:ok, seq_num} = Stellar.Horizon.Accounts.fetch_next_sequence_number(pk1)
+server = Stellar.Horizon.Server.testnet()
+{:ok, seq_num} = Stellar.Horizon.Accounts.fetch_next_sequence_number(server, pk1)
 sequence_number = Stellar.TxBuild.SequenceNumber.new(seq_num + 1)
 
 # 3. build the payment operation
@@ -97,7 +98,7 @@ signature = Stellar.TxBuild.Signature.new(ed25519: secret_key)
   |> Stellar.TxBuild.sign(signature)
   |> Stellar.TxBuild.envelope()
 
-{:ok, submitted_set_options_tx} = Stellar.Horizon.Transactions.create(set_options_tx_envelope)
+{:ok, submitted_set_options_tx} = Stellar.Horizon.Transactions.create(server, set_options_tx_envelope)
 ```
 
 ### 4. Submit the payment transaction
@@ -109,7 +110,7 @@ Since it was added as a signer, it is already pre-authorized and don't need to b
 You only need to submit the transaction envelope to the network. ✅
 
 ```elixir
-{:ok, submitted_payment_tx} = Stellar.Horizon.Transactions.create(payment_tx_envelope)
+{:ok, submitted_payment_tx} = Stellar.Horizon.Transactions.create(server, payment_tx_envelope)
 ```
 
 Once this is submitted, the transaction will be removed from the account as a signer.

--- a/docs/examples/soroban/create_contract.md
+++ b/docs/examples/soroban/create_contract.md
@@ -52,7 +52,7 @@ keypair =
 
 source_account = Account.new(public_key)
 
-{:ok, seq_num} = Stellar.Horizon.Accounts.fetch_next_sequence_number(public_key)
+{:ok, seq_num} = Stellar.Horizon.Accounts.fetch_next_sequence_number(Stellar.Horizon.Server.testnet(), public_key)
 sequence_number = SequenceNumber.new(seq_num)
 
 signature =
@@ -126,7 +126,7 @@ invoke_host_function_op = InvokeHostFunction.new(host_function: host_function)
 
 source_account = Account.new(public_key)
 
-{:ok, seq_num} = Accounts.fetch_next_sequence_number(public_key)
+{:ok, seq_num} = Accounts.fetch_next_sequence_number(Stellar.Horizon.Server.testnet(), public_key)
 sequence_number = SequenceNumber.new(seq_num)
 
 signature = Signature.new(keypair)

--- a/docs/examples/soroban/extend_footprint_ttl.md
+++ b/docs/examples/soroban/extend_footprint_ttl.md
@@ -34,6 +34,7 @@ alias Stellar.TxBuild.{
 alias Stellar.Horizon.Accounts
 alias Stellar.KeyPair
 
+server = Stellar.Horizon.Server.testnet()
 contract_address = "CCNVHP2UAOJAICTQUDSRVZDCB5OJKGQNOJFPOXINELWQHGX33EG34NV2"
 contract_sc_address = SCAddress.new(contract_address)
 key = SCVal.new(ledger_key_contract_instance: nil)
@@ -67,7 +68,7 @@ soroban_data =
 |> SorobanTransactionData.to_xdr()
 
 source_account = Account.new(public_key)
-{:ok, seq_num} = Accounts.fetch_next_sequence_number(public_key)
+{:ok, seq_num} = Accounts.fetch_next_sequence_number(server, public_key)
 sequence_number = SequenceNumber.new(seq_num)
 signature = Signature.new(keypair)
 extend_footprint_ttl_op = ExtendFootprintTTL.new(extend_to: 1000)

--- a/docs/examples/soroban/invoke_contract_functions.md
+++ b/docs/examples/soroban/invoke_contract_functions.md
@@ -29,6 +29,7 @@ alias Stellar.TxBuild.{
 alias Stellar.Horizon.Accounts
 alias Stellar.KeyPair
 
+server = Stellar.Horizon.Server.new()
 contract_address = SCAddress.new("CAMGSYINVVL6WP3Q5WPNL7FS4GZP37TWV7MKIRQF5QMYLK3N2SW4P3RC")
 
 function_name = "hello"
@@ -43,7 +44,7 @@ host_function = HostFunction.new(invoke_contract: args)
 invoke_host_function_op = InvokeHostFunction.new(host_function: host_function)
 keypair = {public_key, _secret} = KeyPair.from_secret_seed("SDR...Q24")
 source_account = Account.new(public_key)
-{:ok, seq_num} = Accounts.fetch_next_sequence_number(public_key)
+{:ok, seq_num} = Accounts.fetch_next_sequence_number(server, public_key)
 sequence_number = SequenceNumber.new(seq_num)
 
 signature = Signature.new(keypair)
@@ -93,6 +94,7 @@ alias Stellar.TxBuild.{
 alias Stellar.Horizon.Accounts
 alias Stellar.KeyPair
 
+server = Stellar.Horizon.Server.new()
 contract_address = SCAddress.new("CAMGSYINVVL6WP3Q5WPNL7FS4GZP37TWV7MKIRQF5QMYLK3N2SW4P3RC")
 
 function_name = "inc"
@@ -110,7 +112,7 @@ args =
 host_function = HostFunction.new(invoke_contract: args)
 invoke_host_function_op = InvokeHostFunction.new(host_function: host_function)
 source_account = Account.new(public_key)
-{:ok, seq_num} = Accounts.fetch_next_sequence_number(public_key)
+{:ok, seq_num} = Accounts.fetch_next_sequence_number(server, public_key)
 sequence_number = SequenceNumber.new(seq_num)
 signature = Signature.new(keypair)
 
@@ -166,6 +168,7 @@ alias Stellar.TxBuild.{
 alias Stellar.Horizon.Accounts
 alias Stellar.KeyPair
 
+server = Stellar.Horizon.Server.new()
 contract_address = SCAddress.new("CAMGSYINVVL6WP3Q5WPNL7FS4GZP37TWV7MKIRQF5QMYLK3N2SW4P3RC")
 
 function_name = "inc"
@@ -193,7 +196,7 @@ host_function = HostFunction.new(invoke_contract: args)
 invoke_host_function_op = InvokeHostFunction.new(host_function: host_function)
 
 source_account = Account.new(submitter_public_key)
-{:ok, seq_num} = Accounts.fetch_next_sequence_number(submitter_public_key)
+{:ok, seq_num} = Accounts.fetch_next_sequence_number(server, submitter_public_key)
 sequence_number = SequenceNumber.new(seq_num)
 signature = Signature.new(submitter_keypair)
 

--- a/docs/examples/soroban/restore_footprint.md
+++ b/docs/examples/soroban/restore_footprint.md
@@ -34,6 +34,7 @@ alias Stellar.TxBuild.{
 alias Stellar.Horizon.Accounts
 alias Stellar.KeyPair
 
+server = Stellar.Horizon.Server.testnet()
 contract_sc_address = SCAddress.new("CAMGSYINVVL6WP3Q5WPNL7FS4GZP37TWV7MKIRQF5QMYLK3N2SW4P3RC")
 key = SCVal.new(ledger_key_contract_instance: nil)
 
@@ -63,7 +64,7 @@ soroban_data =
 |> SorobanTransactionData.to_xdr()
 
 source_account = Account.new(public_key)
-{:ok, seq_num} = Accounts.fetch_next_sequence_number(public_key)
+{:ok, seq_num} = Accounts.fetch_next_sequence_number(server, public_key)
 sequence_number = SequenceNumber.new(seq_num)
 signature = Signature.new(keypair)
 restore_footprint_op = RestoreFootprint.new()

--- a/docs/examples/soroban/upload_contract_code.md
+++ b/docs/examples/soroban/upload_contract_code.md
@@ -19,6 +19,8 @@ alias Stellar.TxBuild.{
 alias Stellar.Horizon.Accounts
 alias Stellar.KeyPair
 
+server = Stellar.Horizon.Server.testnet()
+
 # read file
 {:ok, code} = File.read("file_path/file.wasm")
 
@@ -30,7 +32,7 @@ keypair = {public_key, _secret} = KeyPair.from_secret_seed("SDR...Q24")
 
 source_account = Account.new(public_key)
 
-{:ok, seq_num} = Accounts.fetch_next_sequence_number(public_key)
+{:ok, seq_num} = Accounts.fetch_next_sequence_number(server, public_key)
 sequence_number = SequenceNumber.new(seq_num)
 
 signature = Signature.new(keypair)

--- a/lib/horizon/accounts.ex
+++ b/lib/horizon/accounts.ex
@@ -30,6 +30,7 @@ defmodule Stellar.Horizon.Accounts do
     Transaction
   }
 
+  @type server :: Server.t()
   @type account_id :: String.t()
   @type options :: Keyword.t()
   @type resource :: Account.t() | Collection.t()
@@ -41,17 +42,18 @@ defmodule Stellar.Horizon.Accounts do
   Retrieves information of a specific account.
 
   ## Parameters:
+    * `server`: The Horizon server to query.
     * `account_id`: The account’s public key encoded in a base32 string representation.
 
   ## Examples
 
-      iex> Accounts.retrieve("GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD")
+      iex> Accounts.retrieve(Stellar.Horizon.Server.testnet(), "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD")
       {:ok, %Account{}}
   """
-  @spec retrieve(account_id :: account_id()) :: response()
-  def retrieve(account_id) do
-    :get
-    |> Request.new(@endpoint, path: account_id)
+  @spec retrieve(server :: server(), account_id :: account_id()) :: response()
+  def retrieve(server, account_id) do
+    server
+    |> Request.new(:get, @endpoint, path: account_id)
     |> Request.perform()
     |> Request.results(as: Account)
   end
@@ -61,16 +63,17 @@ defmodule Stellar.Horizon.Accounts do
 
   ## Parameters:
 
+    * `server`: The Horizon server to query.
     * `account_id`: The account’s public key encoded in a base32 string representation.
 
   ## Examples
 
-      iex> Accounts.fetch_next_sequence_number("GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD")
+      iex> Accounts.fetch_next_sequence_number(Stellar.Horizon.Server.testnet(), "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD")
       {:ok, 17218523889687}
   """
-  @spec fetch_next_sequence_number(account_id :: account_id()) :: response()
-  def fetch_next_sequence_number(account_id) do
-    case retrieve(account_id) do
+  @spec fetch_next_sequence_number(server :: server(), account_id :: account_id()) :: response()
+  def fetch_next_sequence_number(server, account_id) do
+    case retrieve(server, account_id) do
       {:ok, %Account{sequence: sequence}} -> {:ok, sequence + 1}
       error -> error
     end
@@ -78,6 +81,9 @@ defmodule Stellar.Horizon.Accounts do
 
   @doc """
   Lists all accounts or by one of these three filters: `signer`, `asset`, or `sponsor`.
+
+  ## Parameters:
+    * `server`: The Horizon server to query.
 
   ## Options
 
@@ -90,34 +96,35 @@ defmodule Stellar.Horizon.Accounts do
 
   ## Examples
 
-      iex> Accounts.all(limit: 2, order: :asc)
+      iex> Accounts.all(Stellar.Horizon.Server.testnet(), limit: 2, order: :asc)
       {:ok, %Collection{records: [%Account{}, ...]}}
 
       # list by sponsor
-      iex> Accounts.all(sponsor: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD")
+      iex> Accounts.all(Stellar.Horizon.Server.testnet(), sponsor: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD")
       {:ok, %Collection{records: [%Account{}, ...]}}
 
       # list by signer
-      iex> Accounts.all(signer: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", order: :desc)
+      iex> Accounts.all(Stellar.Horizon.Server.testnet(), signer: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", order: :desc)
       {:ok, %Collection{records: [%Account{}, ...]}}
 
       # list by canonical asset address
-      iex> Accounts.all(asset: "TEST:GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", limit: 20)
+      iex> Accounts.all(Stellar.Horizon.Server.testnet(), asset: "TEST:GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", limit: 20)
       {:ok, %Collection{records: [%Account{}, ...]}}
   """
-  @spec all(options :: options()) :: response()
-  def all(options \\ []) do
-    :get
-    |> Request.new(@endpoint)
+  @spec all(server :: server(), options :: options()) :: response()
+  def all(server, options \\ []) do
+    server
+    |> Request.new(:get, @endpoint)
     |> Request.add_query(options, extra_params: [:sponsor, :asset, :signer, :liquidity_pool])
     |> Request.perform()
-    |> Request.results(collection: {Account, &all/1})
+    |> Request.results(collection: {Account, &all(server, &1)})
   end
 
   @doc """
   Lists successful transactions for a given account.
 
-  ## Parameters
+  ## Parameters:
+    * `server`: The Horizon server to query.
     * `account_id`: The account’s public key encoded in a base32 string representation.
 
   ## Options
@@ -128,22 +135,23 @@ defmodule Stellar.Horizon.Accounts do
 
   ## Examples
 
-      iex> Accounts.list_transactions("GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", limit: 20)
+      iex> Accounts.list_transactions(Stellar.Horizon.Server.testnet(), "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", limit: 20)
       {:ok, %Collection{records: [%Transaction{}, ...]}}
   """
-  @spec list_transactions(account_id :: account_id(), options :: options()) :: response()
-  def list_transactions(account_id, options \\ []) do
-    :get
-    |> Request.new(@endpoint, path: account_id, segment: "transactions")
+  @spec list_transactions(server :: server(), account_id :: account_id(), options :: options()) :: response()
+  def list_transactions(server, account_id, options \\ []) do
+    server
+    |> Request.new(:get, @endpoint, path: account_id, segment: "transactions")
     |> Request.add_query(options, extra_params: [:include_failed])
     |> Request.perform()
-    |> Request.results(collection: {Transaction, &list_transactions(account_id, &1)})
+    |> Request.results(collection: {Transaction, &list_transactions(server, account_id, &1)})
   end
 
   @doc """
   Lists successful operations for a given account.
 
-  ## Parameters
+  ## Parameters:
+    * `server`: The Horizon server to query.
     * `account_id`: The account’s public key encoded in a base32 string representation.
 
   ## Options
@@ -155,26 +163,27 @@ defmodule Stellar.Horizon.Accounts do
 
   ## Examples
 
-      iex> Accounts.list_transactions("GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", limit: 20)
+      iex> Accounts.list_transactions(Stellar.Horizon.Server.testnet(), "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", limit: 20)
       {:ok, %Collection{records: [%Operation{}, ...]}}
 
       # join transactions
-      iex> Accounts.list_transactions("GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", join: "transactions")
+      iex> Accounts.list_transactions(Stellar.Horizon.Server.testnet(), "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", join: "transactions")
       {:ok, %Collection{records: [%Operation{transaction: %Transaction{}}, ...]}}
   """
-  @spec list_operations(account_id :: account_id(), options :: options()) :: response()
-  def list_operations(account_id, options \\ []) do
-    :get
-    |> Request.new(@endpoint, path: account_id, segment: "operations")
+  @spec list_operations(server :: server(), account_id :: account_id(), options :: options()) :: response()
+  def list_operations(server, account_id, options \\ []) do
+    server
+    |> Request.new(:get, @endpoint, path: account_id, segment: "operations")
     |> Request.add_query(options, extra_params: [:include_failed, :join])
     |> Request.perform()
-    |> Request.results(collection: {Operation, &list_operations(account_id, &1)})
+    |> Request.results(collection: {Operation, &list_operations(server, account_id, &1)})
   end
 
   @doc """
   Lists successful payments for a given account.
 
-  ## Parameters
+  ## Parameters:
+    * `server`: The Horizon server to query.
     * `account_id`: The account’s public key encoded in a base32 string representation.
 
   ## Options
@@ -186,26 +195,27 @@ defmodule Stellar.Horizon.Accounts do
 
   ## Examples
 
-      iex> Accounts.list_payments("GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", limit: 20)
+      iex> Accounts.list_payments(Stellar.Horizon.Server.testnet(), "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", limit: 20)
       {:ok, %Collection{records: [%Operation{body: %Payment{}}, ...]}}
 
       # include failed
-      iex> Accounts.list_payments("GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", include_failed: true)
+      iex> Accounts.list_payments(Stellar.Horizon.Server.testnet(), "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", include_failed: true)
       {:ok, %Collection{records: [%Operation{body: %Payment{}}, ...]}}
   """
-  @spec list_payments(account_id :: account_id(), options :: options()) :: response()
-  def list_payments(account_id, options \\ []) do
-    :get
-    |> Request.new(@endpoint, path: account_id, segment: "payments")
+  @spec list_payments(server :: server(), account_id :: account_id(), options :: options()) :: response()
+  def list_payments(server, account_id, options \\ []) do
+    server
+    |> Request.new(:get, @endpoint, path: account_id, segment: "payments")
     |> Request.add_query(options, extra_params: [:include_failed, :join])
     |> Request.perform()
-    |> Request.results(collection: {Operation, &list_payments(account_id, &1)})
+    |> Request.results(collection: {Operation, &list_payments(server, account_id, &1)})
   end
 
   @doc """
   Lists the effects of a specific account.
 
-  ## Parameters
+  ## Parameters:
+    * `server`: The Horizon server to query.
     * `account_id`: The account’s public key encoded in a base32 string representation.
 
   ## Options
@@ -215,22 +225,23 @@ defmodule Stellar.Horizon.Accounts do
 
   ## Examples
 
-      iex> Accounts.list_effects("GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", limit: 20)
+      iex> Accounts.list_effects(Stellar.Horizon.Server.testnet(), "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", limit: 20)
       {:ok, %Collection{records: [%Effect{}, ...]}}
   """
-  @spec list_effects(account_id :: account_id(), options :: options()) :: response()
-  def list_effects(account_id, options \\ []) do
-    :get
-    |> Request.new(@endpoint, path: account_id, segment: "effects")
+  @spec list_effects(server :: server(), account_id :: account_id(), options :: options()) :: response()
+  def list_effects(server, account_id, options \\ []) do
+    server
+    |> Request.new(:get, @endpoint, path: account_id, segment: "effects")
     |> Request.add_query(options)
     |> Request.perform()
-    |> Request.results(collection: {Effect, &list_effects(account_id, &1)})
+    |> Request.results(collection: {Effect, &list_effects(server, account_id, &1)})
   end
 
   @doc """
   Lists all offers a given account has currently open.
 
-  ## Parameters
+  ## Parameters:
+    * `server`: The Horizon server to query.
     * `account_id`: The account’s public key encoded in a base32 string representation.
 
   ## Options
@@ -240,22 +251,23 @@ defmodule Stellar.Horizon.Accounts do
 
   ## Examples
 
-      iex> Accounts.list_offers("GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", limit: 20)
+      iex> Accounts.list_offers(Stellar.Horizon.Server.testnet(), "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", limit: 20)
       {:ok, %Collection{records: [%Offer{}, ...]}}
   """
-  @spec list_offers(account_id :: account_id(), options :: options()) :: response()
-  def list_offers(account_id, options \\ []) do
-    :get
-    |> Request.new(@endpoint, path: account_id, segment: "offers")
+  @spec list_offers(server :: server(), account_id :: account_id(), options :: options()) :: response()
+  def list_offers(server, account_id, options \\ []) do
+    server
+    |> Request.new(:get, @endpoint, path: account_id, segment: "offers")
     |> Request.add_query(options)
     |> Request.perform()
-    |> Request.results(collection: {Offer, &list_offers(account_id, &1)})
+    |> Request.results(collection: {Offer, &list_offers(server, account_id, &1)})
   end
 
   @doc """
   Lists all trades for a given account.
 
-  ## Parameters
+  ## Parameters:
+    * `server`: The Horizon server to query.
     * `account_id`: The account’s public key encoded in a base32 string representation.
 
   ## Options
@@ -265,34 +277,35 @@ defmodule Stellar.Horizon.Accounts do
 
   ## Examples
 
-      iex> Accounts.list_trades("GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", limit: 20)
+      iex> Accounts.list_trades(Stellar.Horizon.Server.testnet(), "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", limit: 20)
       {:ok, %Collection{records: [%Trade{}, ...]}}
   """
-  @spec list_trades(account_id :: account_id(), options :: options()) :: response()
-  def list_trades(account_id, options \\ []) do
-    :get
-    |> Request.new(@endpoint, path: account_id, segment: "trades")
+  @spec list_trades(server :: server(), account_id :: account_id(), options :: options()) :: response()
+  def list_trades(server, account_id, options \\ []) do
+    server
+    |> Request.new(:get, @endpoint, path: account_id, segment: "trades")
     |> Request.add_query(options)
     |> Request.perform()
-    |> Request.results(collection: {Trade, &list_trades(account_id, &1)})
+    |> Request.results(collection: {Trade, &list_trades(server, account_id, &1)})
   end
 
   @doc """
   Retrieves a single data for a given account.
 
-  ## Parameters
+  ## Parameters:
+    * `server`: The Horizon server to query.
     * `account_id`: The account’s public key encoded in a base32 string representation.
     * `key`: The key name for this data.
 
   ## Examples
 
-      iex> Accounts.data("GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", "config.memo_required")
+      iex> Accounts.data(Stellar.Horizon.Server.testnet(), "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", "config.memo_required")
       {:ok, %Account.Data{}}
   """
-  @spec data(account_id :: account_id(), key :: String.t()) :: response()
-  def data(account_id, key) do
-    :get
-    |> Request.new(@endpoint, path: account_id, segment: "data", segment_path: key)
+  @spec data(server :: server(), account_id :: account_id(), key :: String.t()) :: response()
+  def data(server, account_id, key) do
+    server
+    |> Request.new(:get, @endpoint, path: account_id, segment: "data", segment_path: key)
     |> Request.perform()
     |> Request.results(as: Data)
   end

--- a/lib/horizon/accounts.ex
+++ b/lib/horizon/accounts.ex
@@ -27,7 +27,8 @@ defmodule Stellar.Horizon.Accounts do
     Operation,
     Request,
     Trade,
-    Transaction
+    Transaction,
+    Server
   }
 
   @type server :: Server.t()
@@ -138,7 +139,8 @@ defmodule Stellar.Horizon.Accounts do
       iex> Accounts.list_transactions(Stellar.Horizon.Server.testnet(), "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", limit: 20)
       {:ok, %Collection{records: [%Transaction{}, ...]}}
   """
-  @spec list_transactions(server :: server(), account_id :: account_id(), options :: options()) :: response()
+  @spec list_transactions(server :: server(), account_id :: account_id(), options :: options()) ::
+          response()
   def list_transactions(server, account_id, options \\ []) do
     server
     |> Request.new(:get, @endpoint, path: account_id, segment: "transactions")
@@ -170,7 +172,8 @@ defmodule Stellar.Horizon.Accounts do
       iex> Accounts.list_transactions(Stellar.Horizon.Server.testnet(), "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", join: "transactions")
       {:ok, %Collection{records: [%Operation{transaction: %Transaction{}}, ...]}}
   """
-  @spec list_operations(server :: server(), account_id :: account_id(), options :: options()) :: response()
+  @spec list_operations(server :: server(), account_id :: account_id(), options :: options()) ::
+          response()
   def list_operations(server, account_id, options \\ []) do
     server
     |> Request.new(:get, @endpoint, path: account_id, segment: "operations")
@@ -202,7 +205,8 @@ defmodule Stellar.Horizon.Accounts do
       iex> Accounts.list_payments(Stellar.Horizon.Server.testnet(), "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", include_failed: true)
       {:ok, %Collection{records: [%Operation{body: %Payment{}}, ...]}}
   """
-  @spec list_payments(server :: server(), account_id :: account_id(), options :: options()) :: response()
+  @spec list_payments(server :: server(), account_id :: account_id(), options :: options()) ::
+          response()
   def list_payments(server, account_id, options \\ []) do
     server
     |> Request.new(:get, @endpoint, path: account_id, segment: "payments")
@@ -228,7 +232,8 @@ defmodule Stellar.Horizon.Accounts do
       iex> Accounts.list_effects(Stellar.Horizon.Server.testnet(), "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", limit: 20)
       {:ok, %Collection{records: [%Effect{}, ...]}}
   """
-  @spec list_effects(server :: server(), account_id :: account_id(), options :: options()) :: response()
+  @spec list_effects(server :: server(), account_id :: account_id(), options :: options()) ::
+          response()
   def list_effects(server, account_id, options \\ []) do
     server
     |> Request.new(:get, @endpoint, path: account_id, segment: "effects")
@@ -254,7 +259,8 @@ defmodule Stellar.Horizon.Accounts do
       iex> Accounts.list_offers(Stellar.Horizon.Server.testnet(), "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", limit: 20)
       {:ok, %Collection{records: [%Offer{}, ...]}}
   """
-  @spec list_offers(server :: server(), account_id :: account_id(), options :: options()) :: response()
+  @spec list_offers(server :: server(), account_id :: account_id(), options :: options()) ::
+          response()
   def list_offers(server, account_id, options \\ []) do
     server
     |> Request.new(:get, @endpoint, path: account_id, segment: "offers")
@@ -280,7 +286,8 @@ defmodule Stellar.Horizon.Accounts do
       iex> Accounts.list_trades(Stellar.Horizon.Server.testnet(), "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", limit: 20)
       {:ok, %Collection{records: [%Trade{}, ...]}}
   """
-  @spec list_trades(server :: server(), account_id :: account_id(), options :: options()) :: response()
+  @spec list_trades(server :: server(), account_id :: account_id(), options :: options()) ::
+          response()
   def list_trades(server, account_id, options \\ []) do
     server
     |> Request.new(:get, @endpoint, path: account_id, segment: "trades")

--- a/lib/horizon/assets.ex
+++ b/lib/horizon/assets.ex
@@ -10,8 +10,9 @@ defmodule Stellar.Horizon.Assets do
   Horizon API reference: https://developers.stellar.org/api/resources/assets/
   """
 
-  alias Stellar.Horizon.{Asset, Collection, Error, Request}
+  alias Stellar.Horizon.{Asset, Collection, Error, Request, Server}
 
+  @type server :: Server.t()
   @type asset_code :: String.t()
   @type asset_issuer :: String.t()
   @type options :: Keyword.t()
@@ -23,6 +24,9 @@ defmodule Stellar.Horizon.Assets do
   @doc """
   Lists all assets or by one of these filters: `asset_code` or `asset_issuer`.
 
+  ## Parameters
+    * `server`: The Horizon server to query.
+
   ## Options
 
     * `asset_code`: The code of the asset you would like to filter by.
@@ -33,31 +37,31 @@ defmodule Stellar.Horizon.Assets do
 
   ## Examples
 
-      iex> Assets.all(limit: 20, order: :desc)
+      iex> Assets.all(Stellar.Horizon.Server.testnet(), limit: 20, order: :desc)
       {:ok, %Collection{records: [%Asset{}, ...]}}
 
       # list by asset_code
-      iex> Assets.all(asset_code: "TEST")
+      iex> Assets.all(Stellar.Horizon.Server.testnet(), asset_code: "TEST")
       {:ok, %Collection{records: [%Asset{}, ...]}}
 
       # list by asset_issuer
-      iex> Assets.all(asset_issuer: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD")
+      iex> Assets.all(Stellar.Horizon.Server.testnet(), asset_issuer: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD")
       {:ok, %Collection{records: [%Asset{}, ...]}}
   """
-  @spec all(options :: options()) :: response()
-  def all(options \\ []) do
-    :get
-    |> Request.new(@endpoint)
+  @spec all(server :: server(), options :: options()) :: response()
+  def all(server, options \\ []) do
+    server
+    |> Request.new(:get, @endpoint)
     |> Request.add_query(options, extra_params: [:asset_code, :asset_issuer])
     |> Request.perform()
-    |> Request.results(collection: {Asset, &all/1})
+    |> Request.results(collection: {Asset, &all(server, &1)})
   end
 
   @doc """
   Lists assets matching the given asset code.
 
   ## Parameters:
-
+    * `server`: The Horizon server to query.
     * `asset_code`: The code of the asset you would like to filter by.
 
   ## Options
@@ -68,14 +72,14 @@ defmodule Stellar.Horizon.Assets do
 
   ## Examples
 
-      iex> Assets.list_by_asset_code("TEST")
+      iex> Assets.list_by_asset_code(Stellar.Horizon.Server.testnet(), "TEST")
       {:ok, %Collection{records: [%Asset{asset_code: "TEST"}, ...]}}
   """
-  @spec list_by_asset_code(asset_code :: asset_code(), options :: options()) :: response()
-  def list_by_asset_code(asset_code, options \\ []) do
+  @spec list_by_asset_code(server :: server(), asset_code :: asset_code(), options :: options()) :: response()
+  def list_by_asset_code(server, asset_code, options \\ []) do
     options
     |> Keyword.put(:asset_code, asset_code)
-    |> all()
+    |> (&all(server, &1)).()
   end
 
   @doc """
@@ -83,6 +87,7 @@ defmodule Stellar.Horizon.Assets do
 
   ## Parameters:
 
+    * `server`: The Horizon server to query.
     * `asset_issuer`: The issuer's Account ID for the asset you would like to filter by.
 
   ## Options
@@ -93,13 +98,13 @@ defmodule Stellar.Horizon.Assets do
 
   ## Examples
 
-      iex> Assets.list_by_asset_issuer("GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD")
+      iex> Assets.list_by_asset_issuer(Stellar.Horizon.Server.testnet(), "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD")
       {:ok, %Collection{records: [%Asset{asset_issuer: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD"}, ...]}}
   """
-  @spec list_by_asset_issuer(asset_issuer :: asset_issuer(), options :: options()) :: response()
-  def list_by_asset_issuer(asset_issuer, options \\ []) do
+  @spec list_by_asset_issuer(server :: server(), asset_issuer :: asset_issuer(), options :: options()) :: response()
+  def list_by_asset_issuer(server, asset_issuer, options \\ []) do
     options
     |> Keyword.put(:asset_issuer, asset_issuer)
-    |> all()
+    |> (&all(server, &1)).()
   end
 end

--- a/lib/horizon/assets.ex
+++ b/lib/horizon/assets.ex
@@ -75,7 +75,8 @@ defmodule Stellar.Horizon.Assets do
       iex> Assets.list_by_asset_code(Stellar.Horizon.Server.testnet(), "TEST")
       {:ok, %Collection{records: [%Asset{asset_code: "TEST"}, ...]}}
   """
-  @spec list_by_asset_code(server :: server(), asset_code :: asset_code(), options :: options()) :: response()
+  @spec list_by_asset_code(server :: server(), asset_code :: asset_code(), options :: options()) ::
+          response()
   def list_by_asset_code(server, asset_code, options \\ []) do
     options
     |> Keyword.put(:asset_code, asset_code)
@@ -101,7 +102,11 @@ defmodule Stellar.Horizon.Assets do
       iex> Assets.list_by_asset_issuer(Stellar.Horizon.Server.testnet(), "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD")
       {:ok, %Collection{records: [%Asset{asset_issuer: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD"}, ...]}}
   """
-  @spec list_by_asset_issuer(server :: server(), asset_issuer :: asset_issuer(), options :: options()) :: response()
+  @spec list_by_asset_issuer(
+          server :: server(),
+          asset_issuer :: asset_issuer(),
+          options :: options()
+        ) :: response()
   def list_by_asset_issuer(server, asset_issuer, options \\ []) do
     options
     |> Keyword.put(:asset_issuer, asset_issuer)

--- a/lib/horizon/claimable_balances.ex
+++ b/lib/horizon/claimable_balances.ex
@@ -11,7 +11,15 @@ defmodule Stellar.Horizon.ClaimableBalances do
   Horizon API reference: https://developers.stellar.org/api/resources/claimablebalances/
   """
 
-  alias Stellar.Horizon.{ClaimableBalance, Collection, Error, Operation, Request, Transaction, Server}
+  alias Stellar.Horizon.{
+    ClaimableBalance,
+    Collection,
+    Error,
+    Operation,
+    Request,
+    Transaction,
+    Server
+  }
 
   @type server :: Server.t()
   @type claimable_balance_id :: String.t()
@@ -102,14 +110,20 @@ defmodule Stellar.Horizon.ClaimableBalances do
       iex> ClaimableBalances.list_transactions(Stellar.Horizon.Server.testnet(), "00000000ca6aba5fb0993844e0076f75bee53f2b8014be29cd8f2e6ae19fb0a17fc68695", limit: 20)
       {:ok, %Collection{records: [%Transaction{}, ...]}}
   """
-  @spec list_transactions(server :: server(), claimable_balance_id :: claimable_balance_id(), options :: options()) ::
+  @spec list_transactions(
+          server :: server(),
+          claimable_balance_id :: claimable_balance_id(),
+          options :: options()
+        ) ::
           response()
   def list_transactions(server, claimable_balance_id, options \\ []) do
     server
     |> Request.new(:get, @endpoint, path: claimable_balance_id, segment: "transactions")
     |> Request.add_query(options, extra_params: [:include_failed])
     |> Request.perform()
-    |> Request.results(collection: {Transaction, &list_transactions(server, claimable_balance_id, &1)})
+    |> Request.results(
+      collection: {Transaction, &list_transactions(server, claimable_balance_id, &1)}
+    )
   end
 
   @doc """
@@ -135,14 +149,20 @@ defmodule Stellar.Horizon.ClaimableBalances do
       iex> ClaimableBalances.list_operations(Stellar.Horizon.Server.testnet(), "00000000ca6aba5fb0993844e0076f75bee53f2b8014be29cd8f2e6ae19fb0a17fc68695", join: "transactions")
       {:ok, %Collection{records: [%Operation{transaction: %Transaction{}}, ...]}}
   """
-  @spec list_operations(server :: server(), claimable_balance_id :: claimable_balance_id(), options :: options()) ::
+  @spec list_operations(
+          server :: server(),
+          claimable_balance_id :: claimable_balance_id(),
+          options :: options()
+        ) ::
           response()
   def list_operations(server, claimable_balance_id, options \\ []) do
     server
     |> Request.new(:get, @endpoint, path: claimable_balance_id, segment: "operations")
     |> Request.add_query(options, extra_params: [:include_failed, :join])
     |> Request.perform()
-    |> Request.results(collection: {Operation, &list_operations(server, claimable_balance_id, &1)})
+    |> Request.results(
+      collection: {Operation, &list_operations(server, claimable_balance_id, &1)}
+    )
   end
 
   @doc """
@@ -163,7 +183,8 @@ defmodule Stellar.Horizon.ClaimableBalances do
       iex> ClaimableBalances.list_by_sponsor(Stellar.Horizon.Server.testnet(), "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD")
       {:ok, %Collection{records: [%ClaimableBalance{sponsor: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD"}, ...]}}
   """
-  @spec list_by_sponsor(server :: server(), sponsor :: account_id(), options :: options()) :: response()
+  @spec list_by_sponsor(server :: server(), sponsor :: account_id(), options :: options()) ::
+          response()
   def list_by_sponsor(server, sponsor, options \\ []) do
     options
     |> Keyword.put(:sponsor, sponsor)
@@ -188,7 +209,8 @@ defmodule Stellar.Horizon.ClaimableBalances do
       iex> ClaimableBalances.list_by_claimant("GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD")
       {:ok, %Collection{records: [%ClaimableBalance{claimant: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD"}, ...]}}
   """
-  @spec list_by_claimant(server :: server(), claimant :: account_id(), options :: options()) :: response()
+  @spec list_by_claimant(server :: server(), claimant :: account_id(), options :: options()) ::
+          response()
   def list_by_claimant(server, claimant, options \\ []) do
     options
     |> Keyword.put(:claimant, claimant)

--- a/lib/horizon/client.ex
+++ b/lib/horizon/client.ex
@@ -7,8 +7,8 @@ defmodule Stellar.Horizon.Client do
   @behaviour Client.Spec
 
   @impl true
-  def request(method, path, headers \\ [], body \\ "", opts \\ []),
-    do: impl().request(method, path, headers, body, opts)
+  def request(server, method, path, headers \\ [], body \\ "", opts \\ []),
+    do: impl().request(server, method, path, headers, body, opts)
 
   @spec impl() :: atom()
   defp impl do

--- a/lib/horizon/client/default.ex
+++ b/lib/horizon/client/default.ex
@@ -7,8 +7,7 @@ defmodule Stellar.Horizon.Client.Default do
 
   @behaviour Stellar.Horizon.Client.Spec
 
-  alias Stellar.Network
-  alias Stellar.Horizon.Error
+  alias Stellar.Horizon.{Error, Server}
 
   @type status :: pos_integer()
   @type headers :: [{binary(), binary()}, ...]
@@ -19,8 +18,7 @@ defmodule Stellar.Horizon.Client.Default do
   @type parsed_response :: {:ok, map()} | {:error, Error.t()}
 
   @impl true
-  def request(method, path, headers \\ [], body \\ "", opts \\ []) do
-    base_url = Network.base_url()
+  def request(%Server{url: base_url}, method, path, headers \\ [], body \\ "", opts \\ []) do
     options = http_options(opts)
 
     method

--- a/lib/horizon/client/spec.ex
+++ b/lib/horizon/client/spec.ex
@@ -6,6 +6,7 @@ defmodule Stellar.Horizon.Client.Spec do
   The default is :hackney.
   """
 
+  @type server :: Stellar.Horizon.Server.t()
   @type method :: :get | :post | :put | :delete
   @type headers :: [{binary(), binary()}, ...]
   @type body :: binary()
@@ -16,6 +17,7 @@ defmodule Stellar.Horizon.Client.Spec do
   @type response_error :: {:error, any()}
 
   @callback request(
+              server :: server(),
               method :: method(),
               url :: binary(),
               body :: binary(),

--- a/lib/horizon/effects.ex
+++ b/lib/horizon/effects.ex
@@ -8,8 +8,9 @@ defmodule Stellar.Horizon.Effects do
   Horizon API reference: https://developers.stellar.org/api/resources/effects/
   """
 
-  alias Stellar.Horizon.{Collection, Effect, Error, Request}
+  alias Stellar.Horizon.{Collection, Effect, Error, Request, Server}
 
+  @type server :: Server.t()
   @type options :: Keyword.t()
   @type resource :: Effect.t() | Collection.t()
   @type response :: {:ok, resource()} | {:error, Error.t()}
@@ -19,6 +20,9 @@ defmodule Stellar.Horizon.Effects do
   @doc """
   Lists all effects.
 
+  ## Parameters
+    * `server`: The Horizon server to query.
+
   ## Options
 
     * `cursor`: A number that points to a specific location in a collection of responses and is pulled from the `paging_token` value of a record.
@@ -27,15 +31,15 @@ defmodule Stellar.Horizon.Effects do
 
   ## Examples
 
-      iex> Effects.all(limit: 10, order: :asc)
+      iex> Effects.all(Stellar.Horizon.Server.testnet(), limit: 10, order: :asc)
       {:ok, %Collection{records: [%Effect{}, ...]}}
   """
-  @spec all(options :: options()) :: response()
-  def all(options \\ []) do
-    :get
-    |> Request.new(@endpoint)
+  @spec all(server :: server(), options :: options()) :: response()
+  def all(server, options \\ []) do
+    server
+    |> Request.new(:get, @endpoint)
     |> Request.add_query(options)
     |> Request.perform()
-    |> Request.results(collection: {Effect, &all/1})
+    |> Request.results(collection: {Effect, &all(server, &1)})
   end
 end

--- a/lib/horizon/fee_stats.ex
+++ b/lib/horizon/fee_stats.ex
@@ -8,8 +8,9 @@ defmodule Stellar.Horizon.FeeStats do
   Horizon API reference: https://developers.stellar.org/api/aggregations/fee-stats/
   """
 
-  alias Stellar.Horizon.{Error, FeeStat, Request}
+  alias Stellar.Horizon.{Error, FeeStat, Request, Server}
 
+  @type server :: Server.t()
   @type resource :: FeeStat.t()
   @type response :: {:ok, resource()} | {:error, Error.t()}
 
@@ -18,16 +19,19 @@ defmodule Stellar.Horizon.FeeStats do
   @doc """
   Retrieves information of the fee stats.
 
+  ## Parameters
+    * `server`: The Horizon server to query.
+
   ## Examples
 
-      iex> FeeStats.retrieve()
+      iex> FeeStats.retrieve(Stellar.Horizon.Server.testnet())
       {:ok, %FeeStat{}}
   """
 
-  @spec retrieve :: response()
-  def retrieve do
-    :get
-    |> Request.new(@endpoint)
+  @spec retrieve(server :: server()) :: response()
+  def retrieve(server) do
+    server
+    |> Request.new(:get, @endpoint)
     |> Request.perform()
     |> Request.results(as: FeeStat)
   end

--- a/lib/horizon/ledgers.ex
+++ b/lib/horizon/ledgers.ex
@@ -95,7 +95,8 @@ defmodule Stellar.Horizon.Ledgers do
       iex> Ledgers.list_transactions(Stellar.Horizon.Server.testnet(), 27147222, limit: 20)
       {:ok, %Collection{records: [%Transaction{}, ...]}}
   """
-  @spec list_transactions(server :: server(), sequence :: sequence(), params :: params()) :: response()
+  @spec list_transactions(server :: server(), sequence :: sequence(), params :: params()) ::
+          response()
   def list_transactions(server, sequence, params \\ []) do
     server
     |> Request.new(:get, @endpoint, path: sequence, segment: "transactions")
@@ -127,7 +128,8 @@ defmodule Stellar.Horizon.Ledgers do
       iex> Ledgers.list_operations(Stellar.Horizon.Server.testnet(), 27147222, join: "transactions")
       {:ok, %Collection{records: [%Operation{transaction: %Transaction{}}, ...]}}
   """
-  @spec list_operations(server :: server(), sequence :: sequence(), params :: params()) :: response()
+  @spec list_operations(server :: server(), sequence :: sequence(), params :: params()) ::
+          response()
   def list_operations(server, sequence, params \\ []) do
     server
     |> Request.new(:get, @endpoint, path: sequence, segment: "operations")
@@ -159,7 +161,8 @@ defmodule Stellar.Horizon.Ledgers do
       iex> Ledgers.list_payments(Stellar.Horizon.Server.testnet(), 27147222, include_failed: true)
       {:ok, %Collection{records: [%Operation{body: %Payment{}}, ...]}}
   """
-  @spec list_payments(server :: server(), sequence :: sequence(), params :: params()) :: response()
+  @spec list_payments(server :: server(), sequence :: sequence(), params :: params()) ::
+          response()
   def list_payments(server, sequence, params \\ []) do
     server
     |> Request.new(:get, @endpoint, path: sequence, segment: "payments")

--- a/lib/horizon/ledgers.ex
+++ b/lib/horizon/ledgers.ex
@@ -19,13 +19,15 @@ defmodule Stellar.Horizon.Ledgers do
     Ledger,
     Operation,
     Request,
-    Transaction
+    Transaction,
+    Server
   }
 
   @type sequence :: non_neg_integer()
   @type params :: Keyword.t()
   @type resource :: Ledger.t() | Collection.t()
   @type response :: {:ok, resource()} | {:error, Error.t()}
+  @type server :: Server.t()
 
   @endpoint "ledgers"
 
@@ -33,17 +35,18 @@ defmodule Stellar.Horizon.Ledgers do
   Retrieves information of a specific ledger.
 
   ## Parameters:
+    * `server`: The Horizon server to query.
     * `sequence`: The sequence number of a specific ledger.
 
   ## Examples
 
-      iex> Ledgers.retrieve(27147222)
+      iex> Ledgers.retrieve(Stellar.Horizon.Server.testnet(), 27147222)
       {:ok, %Ledger{}}
   """
-  @spec retrieve(sequence :: sequence()) :: response()
-  def retrieve(sequence) do
-    :get
-    |> Request.new(@endpoint, path: sequence)
+  @spec retrieve(server :: server(), sequence :: sequence()) :: response()
+  def retrieve(server, sequence) do
+    server
+    |> Request.new(:get, @endpoint, path: sequence)
     |> Request.perform()
     |> Request.results(as: Ledger)
   end
@@ -51,6 +54,9 @@ defmodule Stellar.Horizon.Ledgers do
   @doc """
   Lists all ledgers.
 
+  ## Parameters:
+    * `server`: The Horizon server to query.
+
   ## Options
 
     * `cursor`: A number that points to a specific location in a collection of responses and is pulled from the `paging_token` value of a record.
@@ -59,22 +65,23 @@ defmodule Stellar.Horizon.Ledgers do
 
   ## Examples
 
-      iex> Ledgers.all(limit: 10, order: :asc)
+      iex> Ledgers.all(Stellar.Horizon.Server.testnet(), limit: 10, order: :asc)
       {:ok, %Collection{records: [%Ledger{}, ...]}}
   """
-  @spec all(params :: params()) :: response()
-  def all(params \\ []) do
-    :get
-    |> Request.new(@endpoint)
+  @spec all(server :: server(), params :: params()) :: response()
+  def all(server, params \\ []) do
+    server
+    |> Request.new(:get, @endpoint)
     |> Request.add_query(params)
     |> Request.perform()
-    |> Request.results(collection: {Ledger, &all/1})
+    |> Request.results(collection: {Ledger, &all(server, &1)})
   end
 
   @doc """
   Lists successful transactions in a specific ledger.
 
   ## Parameters
+    * `server`: The Horizon server to query.
     * `sequence`: The sequence number of a specific ledger.
 
   ## Options
@@ -85,22 +92,23 @@ defmodule Stellar.Horizon.Ledgers do
 
   ## Examples
 
-      iex> Ledgers.list_transactions(27147222, limit: 20)
+      iex> Ledgers.list_transactions(Stellar.Horizon.Server.testnet(), 27147222, limit: 20)
       {:ok, %Collection{records: [%Transaction{}, ...]}}
   """
-  @spec list_transactions(sequence :: sequence(), params :: params()) :: response()
-  def list_transactions(sequence, params \\ []) do
-    :get
-    |> Request.new(@endpoint, path: sequence, segment: "transactions")
+  @spec list_transactions(server :: server(), sequence :: sequence(), params :: params()) :: response()
+  def list_transactions(server, sequence, params \\ []) do
+    server
+    |> Request.new(:get, @endpoint, path: sequence, segment: "transactions")
     |> Request.add_query(params, extra_params: [:include_failed])
     |> Request.perform()
-    |> Request.results(collection: {Transaction, &list_transactions(sequence, &1)})
+    |> Request.results(collection: {Transaction, &list_transactions(server, sequence, &1)})
   end
 
   @doc """
   Lists successful operations in a specific ledger.
 
   ## Parameters
+    * `server`: The Horizon server to query.
     * `sequence`: The sequence number of a specific ledger.
 
   ## Options
@@ -112,26 +120,27 @@ defmodule Stellar.Horizon.Ledgers do
 
   ## Examples
 
-      iex> Ledgers.list_operations(27147222, limit: 20)
+      iex> Ledgers.list_operations(Stellar.Horizon.Server.testnet(), 27147222, limit: 20)
       {:ok, %Collection{records: [%Operation{}, ...]}}
 
       # join transactions
-      iex> Ledgers.list_operations(27147222, join: "transactions")
+      iex> Ledgers.list_operations(Stellar.Horizon.Server.testnet(), 27147222, join: "transactions")
       {:ok, %Collection{records: [%Operation{transaction: %Transaction{}}, ...]}}
   """
-  @spec list_operations(sequence :: sequence(), params :: params()) :: response()
-  def list_operations(sequence, params \\ []) do
-    :get
-    |> Request.new(@endpoint, path: sequence, segment: "operations")
+  @spec list_operations(server :: server(), sequence :: sequence(), params :: params()) :: response()
+  def list_operations(server, sequence, params \\ []) do
+    server
+    |> Request.new(:get, @endpoint, path: sequence, segment: "operations")
     |> Request.add_query(params, extra_params: [:include_failed, :join])
     |> Request.perform()
-    |> Request.results(collection: {Operation, &list_operations(sequence, &1)})
+    |> Request.results(collection: {Operation, &list_operations(server, sequence, &1)})
   end
 
   @doc """
   Lists successful payments in a specific ledger.
 
   ## Parameters
+    * `server`: The Horizon server to query.
     * `sequence`: The sequence number of a specific ledger.
 
   ## Options
@@ -143,26 +152,27 @@ defmodule Stellar.Horizon.Ledgers do
 
   ## Examples
 
-      iex> Ledgers.list_payments(27147222, limit: 20)
+      iex> Ledgers.list_payments(Stellar.Horizon.Server.testnet(), 27147222, limit: 20)
       {:ok, %Collection{records: [%Operation{body: %Payment{}}, ...]}}
 
       # include failed
-      iex> Ledgers.list_payments(27147222, include_failed: true)
+      iex> Ledgers.list_payments(Stellar.Horizon.Server.testnet(), 27147222, include_failed: true)
       {:ok, %Collection{records: [%Operation{body: %Payment{}}, ...]}}
   """
-  @spec list_payments(sequence :: sequence(), params :: params()) :: response()
-  def list_payments(sequence, params \\ []) do
-    :get
-    |> Request.new(@endpoint, path: sequence, segment: "payments")
+  @spec list_payments(server :: server(), sequence :: sequence(), params :: params()) :: response()
+  def list_payments(server, sequence, params \\ []) do
+    server
+    |> Request.new(:get, @endpoint, path: sequence, segment: "payments")
     |> Request.add_query(params, extra_params: [:include_failed, :join])
     |> Request.perform()
-    |> Request.results(collection: {Operation, &list_payments(sequence, &1)})
+    |> Request.results(collection: {Operation, &list_payments(server, sequence, &1)})
   end
 
   @doc """
   Lists the effects of a specific ledger.
 
   ## Parameters
+    * `server`: The Horizon server to query.
     * `sequence`: The sequence number of a specific ledger.
 
   ## Options
@@ -172,15 +182,15 @@ defmodule Stellar.Horizon.Ledgers do
 
   ## Examples
 
-      iex> Ledgers.list_effects(27147222, limit: 20)
+      iex> Ledgers.list_effects(Stellar.Horizon.Server.testnet(), 27147222, limit: 20)
       {:ok, %Collection{records: [%Effect{}, ...]}}
   """
-  @spec list_effects(sequence :: sequence(), params :: params()) :: response()
-  def list_effects(sequence, params \\ []) do
-    :get
-    |> Request.new(@endpoint, path: sequence, segment: "effects")
+  @spec list_effects(server :: server(), sequence :: sequence(), params :: params()) :: response()
+  def list_effects(server, sequence, params \\ []) do
+    server
+    |> Request.new(:get, @endpoint, path: sequence, segment: "effects")
     |> Request.add_query(params)
     |> Request.perform()
-    |> Request.results(collection: {Effect, &list_effects(sequence, &1)})
+    |> Request.results(collection: {Effect, &list_effects(server, sequence, &1)})
   end
 end

--- a/lib/horizon/liquidity_pools.ex
+++ b/lib/horizon/liquidity_pools.ex
@@ -22,7 +22,7 @@ defmodule Stellar.Horizon.LiquidityPools do
     Request,
     Server,
     Trade,
-    Transaction,
+    Transaction
   }
 
   @type server :: Server.t()
@@ -106,7 +106,11 @@ defmodule Stellar.Horizon.LiquidityPools do
       iex> LiquidityPools.list_effects(Stellar.Horizon.Server.testnet(), "001365fc79ca661f31ba3ee0849ae4ba36f5c377243242d37fad5b1bb8912dbc", limit: 20)
       {:ok, %Collection{records: [%Effect{}, ...]}}
   """
-  @spec list_effects(server :: server(), liquidity_pool_id :: liquidity_pool_id(), options :: options()) :: response()
+  @spec list_effects(
+          server :: server(),
+          liquidity_pool_id :: liquidity_pool_id(),
+          options :: options()
+        ) :: response()
   def list_effects(server, liquidity_pool_id, options \\ []) do
     server
     |> Request.new(:get, @endpoint, path: liquidity_pool_id, segment: "effects")
@@ -132,7 +136,11 @@ defmodule Stellar.Horizon.LiquidityPools do
       iex> LiquidityPools.list_trades(Stellar.Horizon.Server.testnet(), "001365fc79ca661f31ba3ee0849ae4ba36f5c377243242d37fad5b1bb8912dbc", limit: 20)
       {:ok, %Collection{records: [%Trade{}, ...]}}
   """
-  @spec list_trades(server :: server(), liquidity_pool_id :: liquidity_pool_id(), options :: options()) :: response()
+  @spec list_trades(
+          server :: server(),
+          liquidity_pool_id :: liquidity_pool_id(),
+          options :: options()
+        ) :: response()
   def list_trades(server, liquidity_pool_id, options \\ []) do
     server
     |> Request.new(:get, @endpoint, path: liquidity_pool_id, segment: "trades")
@@ -159,14 +167,20 @@ defmodule Stellar.Horizon.LiquidityPools do
       iex> LiquidityPools.list_transactions(Stellar.Horizon.Server.testnet(), "001365fc79ca661f31ba3ee0849ae4ba36f5c377243242d37fad5b1bb8912dbc", limit: 20)
       {:ok, %Collection{records: [%Transaction{}, ...]}}
   """
-  @spec list_transactions(server :: server(), liquidity_pool_id :: liquidity_pool_id(), options :: options()) ::
+  @spec list_transactions(
+          server :: server(),
+          liquidity_pool_id :: liquidity_pool_id(),
+          options :: options()
+        ) ::
           response()
   def list_transactions(server, liquidity_pool_id, options \\ []) do
     server
     |> Request.new(:get, @endpoint, path: liquidity_pool_id, segment: "transactions")
     |> Request.add_query(options, extra_options: [:include_failed])
     |> Request.perform()
-    |> Request.results(collection: {Transaction, &list_transactions(server, liquidity_pool_id, &1)})
+    |> Request.results(
+      collection: {Transaction, &list_transactions(server, liquidity_pool_id, &1)}
+    )
   end
 
   @doc """
@@ -192,7 +206,11 @@ defmodule Stellar.Horizon.LiquidityPools do
       iex> LiquidityPools.list_operations(Stellar.Horizon.Server.testnet(), "001365fc79ca661f31ba3ee0849ae4ba36f5c377243242d37fad5b1bb8912dbc", join: "transactions")
       {:ok, %Collection{records: [%Operation{transaction: %Transaction{}}, ...]}}
   """
-  @spec list_operations(server :: server(), liquidity_pool_id :: liquidity_pool_id(), options :: options()) ::
+  @spec list_operations(
+          server :: server(),
+          liquidity_pool_id :: liquidity_pool_id(),
+          options :: options()
+        ) ::
           response()
   def list_operations(server, liquidity_pool_id, options \\ []) do
     server

--- a/lib/horizon/liquidity_pools.ex
+++ b/lib/horizon/liquidity_pools.ex
@@ -20,10 +20,12 @@ defmodule Stellar.Horizon.LiquidityPools do
     LiquidityPool,
     Operation,
     Request,
+    Server,
     Trade,
-    Transaction
+    Transaction,
   }
 
+  @type server :: Server.t()
   @type liquidity_pool_id :: String.t()
   @type options :: Keyword.t()
   @type resource :: LiquidityPool.t() | Collection.t()
@@ -35,23 +37,27 @@ defmodule Stellar.Horizon.LiquidityPools do
   Retrieves information of a specific liquidity pool.
 
   ## Parameters:
+    * `server`: The Horizon server to query.
     * `liquidity_pool_id`: A liquidity pool’s id encoded in a hex string representation.
 
   ## Examples
 
-      iex> LiquidityPools.retrieve("001365fc79ca661f31ba3ee0849ae4ba36f5c377243242d37fad5b1bb8912dbc")
+      iex> LiquidityPools.retrieve(Stellar.Horizon.Server.testnet(), "001365fc79ca661f31ba3ee0849ae4ba36f5c377243242d37fad5b1bb8912dbc")
       {:ok, %LiquidityPool{}}
   """
-  @spec retrieve(liquidity_pool_id :: liquidity_pool_id()) :: response()
-  def retrieve(liquidity_pool_id) do
-    :get
-    |> Request.new(@endpoint, path: liquidity_pool_id)
+  @spec retrieve(server :: server(), liquidity_pool_id :: liquidity_pool_id()) :: response()
+  def retrieve(server, liquidity_pool_id) do
+    server
+    |> Request.new(:get, @endpoint, path: liquidity_pool_id)
     |> Request.perform()
     |> Request.results(as: LiquidityPool)
   end
 
   @doc """
   Lists all available claimable balances.
+
+  ## Parameters:
+    * `server`: The Horizon server to query.
 
   ## Options
 
@@ -63,30 +69,31 @@ defmodule Stellar.Horizon.LiquidityPools do
 
   ## Examples
 
-      iex> LiquidityPools.all(limit: 2, order: :asc)
+      iex> LiquidityPools.all(Stellar.Horizon.Server.testnet(), limit: 2, order: :asc)
       {:ok, %Collection{records: [%LiquidityPool{}, ...]}}
 
       # list by reserves
-      iex> LiquidityPools.all(reserves: "TEST:GCXMW..., TEST2:GCXMW...")
+      iex> LiquidityPools.all(Stellar.Horizon.Server.testnet(), reserves: "TEST:GCXMW..., TEST2:GCXMW...")
       {:ok, %Collection{records: [%LiquidityPool{}, ...]}}
 
       # list by account
-      iex> LiquidityPools.all(account: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", order: :desc)
+      iex> LiquidityPools.all(Stellar.Horizon.Server.testnet(), account: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD", order: :desc)
       {:ok, %Collection{records: [%LiquidityPool{}, ...]}}
   """
-  @spec all(options :: options()) :: response()
-  def all(options \\ []) do
-    :get
-    |> Request.new(@endpoint)
+  @spec all(server :: server(), options :: options()) :: response()
+  def all(server, options \\ []) do
+    server
+    |> Request.new(:get, @endpoint)
     |> Request.add_query(options, extra_options: [:reserves, :account])
     |> Request.perform()
-    |> Request.results(collection: {LiquidityPool, &all/1})
+    |> Request.results(collection: {LiquidityPool, &all(server, &1)})
   end
 
   @doc """
   Lists the effects of a specific liquidity pool.
 
   ## Parameters
+    * `server`: The Horizon server to query.
     * `liquidity_pool_id`: A liquidity pool’s id encoded in a hex string representation.
 
   ## Options
@@ -96,22 +103,23 @@ defmodule Stellar.Horizon.LiquidityPools do
 
   ## Examples
 
-      iex> LiquidityPools.list_effects("001365fc79ca661f31ba3ee0849ae4ba36f5c377243242d37fad5b1bb8912dbc", limit: 20)
+      iex> LiquidityPools.list_effects(Stellar.Horizon.Server.testnet(), "001365fc79ca661f31ba3ee0849ae4ba36f5c377243242d37fad5b1bb8912dbc", limit: 20)
       {:ok, %Collection{records: [%Effect{}, ...]}}
   """
-  @spec list_effects(liquidity_pool_id :: liquidity_pool_id(), options :: options()) :: response()
-  def list_effects(liquidity_pool_id, options \\ []) do
-    :get
-    |> Request.new(@endpoint, path: liquidity_pool_id, segment: "effects")
+  @spec list_effects(server :: server(), liquidity_pool_id :: liquidity_pool_id(), options :: options()) :: response()
+  def list_effects(server, liquidity_pool_id, options \\ []) do
+    server
+    |> Request.new(:get, @endpoint, path: liquidity_pool_id, segment: "effects")
     |> Request.add_query(options)
     |> Request.perform()
-    |> Request.results(collection: {Effect, &list_effects(liquidity_pool_id, &1)})
+    |> Request.results(collection: {Effect, &list_effects(server, liquidity_pool_id, &1)})
   end
 
   @doc """
   Lists the successful trades fulfilled by the given liquidity pool.
 
   ## Parameters
+    * `server`: The Horizon server to query.
     * `liquidity_pool_id`: A liquidity pool’s id encoded in a hex string representation.
 
   ## Options
@@ -121,22 +129,23 @@ defmodule Stellar.Horizon.LiquidityPools do
 
   ## Examples
 
-      iex> LiquidityPools.list_trades("001365fc79ca661f31ba3ee0849ae4ba36f5c377243242d37fad5b1bb8912dbc", limit: 20)
+      iex> LiquidityPools.list_trades(Stellar.Horizon.Server.testnet(), "001365fc79ca661f31ba3ee0849ae4ba36f5c377243242d37fad5b1bb8912dbc", limit: 20)
       {:ok, %Collection{records: [%Trade{}, ...]}}
   """
-  @spec list_trades(liquidity_pool_id :: liquidity_pool_id(), options :: options()) :: response()
-  def list_trades(liquidity_pool_id, options \\ []) do
-    :get
-    |> Request.new(@endpoint, path: liquidity_pool_id, segment: "trades")
+  @spec list_trades(server :: server(), liquidity_pool_id :: liquidity_pool_id(), options :: options()) :: response()
+  def list_trades(server, liquidity_pool_id, options \\ []) do
+    server
+    |> Request.new(:get, @endpoint, path: liquidity_pool_id, segment: "trades")
     |> Request.add_query(options)
     |> Request.perform()
-    |> Request.results(collection: {Trade, &list_trades(liquidity_pool_id, &1)})
+    |> Request.results(collection: {Trade, &list_trades(server, liquidity_pool_id, &1)})
   end
 
   @doc """
   Lists successful transactions referencing a given liquidity pool.
 
   ## Parameters
+    * `server`: The Horizon server to query.
     * `liquidity_pool_id`: A liquidity pool’s id encoded in a hex string representation.
 
   ## Options
@@ -147,23 +156,24 @@ defmodule Stellar.Horizon.LiquidityPools do
 
   ## Examples
 
-      iex> LiquidityPools.list_transactions("001365fc79ca661f31ba3ee0849ae4ba36f5c377243242d37fad5b1bb8912dbc", limit: 20)
+      iex> LiquidityPools.list_transactions(Stellar.Horizon.Server.testnet(), "001365fc79ca661f31ba3ee0849ae4ba36f5c377243242d37fad5b1bb8912dbc", limit: 20)
       {:ok, %Collection{records: [%Transaction{}, ...]}}
   """
-  @spec list_transactions(liquidity_pool_id :: liquidity_pool_id(), options :: options()) ::
+  @spec list_transactions(server :: server(), liquidity_pool_id :: liquidity_pool_id(), options :: options()) ::
           response()
-  def list_transactions(liquidity_pool_id, options \\ []) do
-    :get
-    |> Request.new(@endpoint, path: liquidity_pool_id, segment: "transactions")
+  def list_transactions(server, liquidity_pool_id, options \\ []) do
+    server
+    |> Request.new(:get, @endpoint, path: liquidity_pool_id, segment: "transactions")
     |> Request.add_query(options, extra_options: [:include_failed])
     |> Request.perform()
-    |> Request.results(collection: {Transaction, &list_transactions(liquidity_pool_id, &1)})
+    |> Request.results(collection: {Transaction, &list_transactions(server, liquidity_pool_id, &1)})
   end
 
   @doc """
   Lists successful operations referencing a given liquidity pool.
 
   ## Parameters
+    * `server`: The Horizon server to query.
     * `liquidity_pool_id`: A liquidity pool’s id encoded in a hex string representation.
 
   ## Options
@@ -175,20 +185,20 @@ defmodule Stellar.Horizon.LiquidityPools do
 
   ## Examples
 
-      iex> LiquidityPools.list_operations("001365fc79ca661f31ba3ee0849ae4ba36f5c377243242d37fad5b1bb8912dbc", limit: 20)
+      iex> LiquidityPools.list_operations(Stellar.Horizon.Server.testnet(), "001365fc79ca661f31ba3ee0849ae4ba36f5c377243242d37fad5b1bb8912dbc", limit: 20)
       {:ok, %Collection{records: [%Operation{}, ...]}}
 
       # join transactions
-      iex> LiquidityPools.list_operations("001365fc79ca661f31ba3ee0849ae4ba36f5c377243242d37fad5b1bb8912dbc", join: "transactions")
+      iex> LiquidityPools.list_operations(Stellar.Horizon.Server.testnet(), "001365fc79ca661f31ba3ee0849ae4ba36f5c377243242d37fad5b1bb8912dbc", join: "transactions")
       {:ok, %Collection{records: [%Operation{transaction: %Transaction{}}, ...]}}
   """
-  @spec list_operations(liquidity_pool_id :: liquidity_pool_id(), options :: options()) ::
+  @spec list_operations(server :: server(), liquidity_pool_id :: liquidity_pool_id(), options :: options()) ::
           response()
-  def list_operations(liquidity_pool_id, options \\ []) do
-    :get
-    |> Request.new(@endpoint, path: liquidity_pool_id, segment: "operations")
+  def list_operations(server, liquidity_pool_id, options \\ []) do
+    server
+    |> Request.new(:get, @endpoint, path: liquidity_pool_id, segment: "operations")
     |> Request.add_query(options, extra_options: [:include_failed, :join])
     |> Request.perform()
-    |> Request.results(collection: {Operation, &list_operations(liquidity_pool_id, &1)})
+    |> Request.results(collection: {Operation, &list_operations(server, liquidity_pool_id, &1)})
   end
 end

--- a/lib/horizon/offers.ex
+++ b/lib/horizon/offers.ex
@@ -125,7 +125,8 @@ defmodule Stellar.Horizon.Offers do
       iex> Offers.list_trades(Stellar.Horizon.Server.testnet(), 165563085, limit: 20)
       {:ok, %Collection{records: [%Trade{}, ...]}}
   """
-  @spec list_trades(server :: server(), offer_id :: offer_id(), options :: options()) :: response()
+  @spec list_trades(server :: server(), offer_id :: offer_id(), options :: options()) ::
+          response()
   def list_trades(server, offer_id, options \\ []) do
     server
     |> Request.new(:get, @endpoint, path: offer_id, segment: "trades")

--- a/lib/horizon/operations.ex
+++ b/lib/horizon/operations.ex
@@ -34,7 +34,8 @@ defmodule Stellar.Horizon.Operations do
       iex> Operations.retrieve(Stellar.Horizon.Server.testnet(), 121693057904021505)
       {:ok, %Operation{}}
   """
-  @spec retrieve(server :: server(), operation_id :: operation_id(), options :: options()) :: response()
+  @spec retrieve(server :: server(), operation_id :: operation_id(), options :: options()) ::
+          response()
   def retrieve(server, operation_id, options \\ []) do
     server
     |> Request.new(:get, @endpoint, path: operation_id)
@@ -123,7 +124,8 @@ defmodule Stellar.Horizon.Operations do
       iex> Operations.list_effects(Stellar.Horizon.Server.testnet(), 121693057904021505, limit: 20)
       {:ok, %Collection{records: [%Effect{}, ...]}}
   """
-  @spec list_effects(server :: server(), operation_id :: operation_id(), options :: options()) :: response()
+  @spec list_effects(server :: server(), operation_id :: operation_id(), options :: options()) ::
+          response()
   def list_effects(server, operation_id, options \\ []) do
     server
     |> Request.new(:get, @endpoint, path: operation_id, segment: "effects")

--- a/lib/horizon/operations.ex
+++ b/lib/horizon/operations.ex
@@ -11,12 +11,13 @@ defmodule Stellar.Horizon.Operations do
   Horizon API reference: https://developers.stellar.org/api/resources/operations/
   """
 
-  alias Stellar.Horizon.{Collection, Effect, Error, Operation, Request}
+  alias Stellar.Horizon.{Collection, Effect, Error, Operation, Request, Server}
 
   @type operation_id :: String.t()
   @type options :: Keyword.t()
   @type resource :: Operation.t() | Collection.t()
   @type response :: {:ok, resource()} | {:error, Error.t()}
+  @type server :: Server.t()
 
   @endpoint "operations"
   @payments_endpoint "payments"
@@ -25,17 +26,18 @@ defmodule Stellar.Horizon.Operations do
   Retrieves information of a specific operation.
 
   ## Parameters:
+    * `server`: The Horizon server to query.
     * `operation_id`: The ID number for the operation.
 
   ## Examples
 
-      iex> Operations.retrieve(121693057904021505)
+      iex> Operations.retrieve(Stellar.Horizon.Server.testnet(), 121693057904021505)
       {:ok, %Operation{}}
   """
-  @spec retrieve(operation_id :: operation_id(), options :: options()) :: response()
-  def retrieve(operation_id, options \\ []) do
-    :get
-    |> Request.new(@endpoint, path: operation_id)
+  @spec retrieve(server :: server(), operation_id :: operation_id(), options :: options()) :: response()
+  def retrieve(server, operation_id, options \\ []) do
+    server
+    |> Request.new(:get, @endpoint, path: operation_id)
     |> Request.add_query(options, extra_params: [:join])
     |> Request.perform()
     |> Request.results(as: Operation)
@@ -44,6 +46,9 @@ defmodule Stellar.Horizon.Operations do
   @doc """
   Lists all successful operations.
 
+  ## Parameters:
+    * `server`: The Horizon server to query.
+
   ## Options
 
     * `cursor`: A number that points to a specific location in a collection of responses and is pulled from the `paging_token` value of a record.
@@ -54,29 +59,32 @@ defmodule Stellar.Horizon.Operations do
 
   ## Examples
 
-      iex> Operations.all(limit: 10, order: :asc)
+      iex> Operations.all(Stellar.Horizon.Server.testnet(), limit: 10, order: :asc)
       {:ok, %Collection{records: [%Operation{}, ...]}}
 
       # include failed
-      iex> Operations.all(limit: 10, include_failed: true)
+      iex> Operations.all(Stellar.Horizon.Server.testnet(), limit: 10, include_failed: true)
       {:ok, %Collection{records: [%Operation{}, ...]}}
 
       # join transactions
-      iex> Operations.all(limit: 10, join: "transactions")
+      iex> Operations.all(Stellar.Horizon.Server.testnet(), limit: 10, join: "transactions")
       {:ok, %Collection{records: [%Operation{transaction: %Transaction{}}, ...]}}
   """
-  @spec all(options :: options()) :: response()
-  def all(options \\ []) do
-    :get
-    |> Request.new(@endpoint)
+  @spec all(server :: server(), options :: options()) :: response()
+  def all(server, options \\ []) do
+    server
+    |> Request.new(:get, @endpoint)
     |> Request.add_query(options, extra_params: [:include_failed, :join])
     |> Request.perform()
-    |> Request.results(collection: {Operation, &all/1})
+    |> Request.results(collection: {Operation, &all(server, &1)})
   end
 
   @doc """
   Lists successful payment-related operations.
 
+  ## Parameters
+    * `server`: The Horizon server to query.
+
   ## Options
     * `cursor`: A number that points to a specific location in a collection of responses and is pulled from the `paging_token` value of a record.
     * `order`: A designation of the order in which records should appear. Options include `asc` (ascending) or `desc` (descending).
@@ -86,22 +94,23 @@ defmodule Stellar.Horizon.Operations do
 
   ## Examples
 
-      iex> Operations.list_payments(limit: 20)
+      iex> Operations.list_payments(Stellar.Horizon.Server.testnet(), limit: 20)
       {:ok, %Collection{records: [%Operation{body: %Payment{}}, ...]}}
   """
-  @spec list_payments(options :: options()) :: response()
-  def list_payments(options \\ []) do
-    :get
-    |> Request.new(@payments_endpoint)
+  @spec list_payments(server :: server(), options :: options()) :: response()
+  def list_payments(server, options \\ []) do
+    server
+    |> Request.new(:get, @payments_endpoint)
     |> Request.add_query(options, extra_params: [:include_failed, :join])
     |> Request.perform()
-    |> Request.results(collection: {Operation, &list_payments/1})
+    |> Request.results(collection: {Operation, &list_payments(server, &1)})
   end
 
   @doc """
   Lists the effects of a specific operation.
 
   ## Parameters
+    * `server`: The Horizon server to query.
     * `operation_id`: The ID number for the operation.
 
   ## Options
@@ -111,15 +120,15 @@ defmodule Stellar.Horizon.Operations do
 
   ## Examples
 
-      iex> Operations.list_effects(121693057904021505, limit: 20)
+      iex> Operations.list_effects(Stellar.Horizon.Server.testnet(), 121693057904021505, limit: 20)
       {:ok, %Collection{records: [%Effect{}, ...]}}
   """
-  @spec list_effects(operation_id :: operation_id(), options :: options()) :: response()
-  def list_effects(operation_id, options \\ []) do
-    :get
-    |> Request.new(@endpoint, path: operation_id, segment: "effects")
+  @spec list_effects(server :: server(), operation_id :: operation_id(), options :: options()) :: response()
+  def list_effects(server, operation_id, options \\ []) do
+    server
+    |> Request.new(:get, @endpoint, path: operation_id, segment: "effects")
     |> Request.add_query(options)
     |> Request.perform()
-    |> Request.results(collection: {Effect, &list_effects(operation_id, &1)})
+    |> Request.results(collection: {Effect, &list_effects(server, operation_id, &1)})
   end
 end

--- a/lib/horizon/payment_paths.ex
+++ b/lib/horizon/payment_paths.ex
@@ -9,8 +9,9 @@ defmodule Stellar.Horizon.PaymentPaths do
   Horizon API reference: https://developers.stellar.org/api/aggregations/paths/
   """
 
-  alias Stellar.Horizon.{Error, Paths, Request, RequestParams}
+  alias Stellar.Horizon.{Error, Paths, Request, RequestParams, Server}
 
+  @type server :: Server.t()
   @type args :: Keyword.t()
   @type opt :: atom()
   @type path :: String.t()
@@ -24,6 +25,7 @@ defmodule Stellar.Horizon.PaymentPaths do
 
   ## Parameters
 
+    * `server`: The Horizon server to query.
     * `source_account`: The Stellar address of the sender.
     * `destination_asset`: `:native` or `[code: "destination_asset_code", issuer: "destination_asset_issuer"]`
     * `destination_amount`: The amount of the destination asset that should be received.
@@ -34,34 +36,39 @@ defmodule Stellar.Horizon.PaymentPaths do
 
   ## Examples
 
-      iex> PaymentPaths.list_paths(source_account: "GBRSLTT74SKP62KJ7ENTMP5V4R7UGB6E5UQESNIIRWUNRCCUO4ZMFM4C",
-                                   destination_asset: :native,
-                                   destination_amount: 5
-                                  )
+      iex> PaymentPaths.list_paths(
+        Stellar.Horizon.Server.testnet(),
+        source_account: "GBRSLTT74SKP62KJ7ENTMP5V4R7UGB6E5UQESNIIRWUNRCCUO4ZMFM4C",
+        destination_asset: :native,
+        destination_amount: 5
+      )
       {:ok, %Paths{records: [%Path{}, ...]}}
 
       # list with `destination_account`
-      iex> PaymentPaths.list_paths(source_account: "GBRSLTT74SKP62KJ7ENTMP5V4R7UGB6E5UQESNIIRWUNRCCUO4ZMFM4C",
-                                   destination_asset: :native,
-                                   destination_amount: 5,
-                                   destination_account: "GBRSLTT74SKP62KJ7ENTMP5V4R7UGB6E5UQESNIIRWUNRCCUO4ZMFM4C"
-                                  )
+      iex> PaymentPaths.list_paths(Stellar.Horizon.Server.testnet(),
+        source_account: "GBRSLTT74SKP62KJ7ENTMP5V4R7UGB6E5UQESNIIRWUNRCCUO4ZMFM4C",
+        destination_asset: :native,
+        destination_amount: 5,
+        destination_account: "GBRSLTT74SKP62KJ7ENTMP5V4R7UGB6E5UQESNIIRWUNRCCUO4ZMFM4C"
+      )
       {:ok, %Paths{records: [%Path{}, ...]}}
 
       # list with more options
-      iex> PaymentPaths.list_paths(source_account: "GBRSLTT74SKP62KJ7ENTMP5V4R7UGB6E5UQESNIIRWUNRCCUO4ZMFM4C",
-                                   destination_asset: [
-                                     code: "TEST",
-                                     issuer: "GA654JC6QLA3ZH4O5V7X5NPM7KEWHKRG5GJA4PETK4SOFBUJLCCN74KQ"
-                                   ],
-                                   destination_amount: 5,
-                                   destination_account: "GBRSLTT74SKP62KJ7ENTMP5V4R7UGB6E5UQESNIIRWUNRCCUO4ZMFM4C"
-                                  )
+      iex> PaymentPaths.list_paths(
+        Stellar.Horizon.Server.testnet(),
+          source_account: "GBRSLTT74SKP62KJ7ENTMP5V4R7UGB6E5UQESNIIRWUNRCCUO4ZMFM4C",
+          destination_asset: [
+            code: "TEST",
+            issuer: "GA654JC6QLA3ZH4O5V7X5NPM7KEWHKRG5GJA4PETK4SOFBUJLCCN74KQ"
+          ],
+          destination_amount: 5,
+          destination_account: "GBRSLTT74SKP62KJ7ENTMP5V4R7UGB6E5UQESNIIRWUNRCCUO4ZMFM4C"
+        )
       {:ok, %Paths{records: [%Path{}, ...]}}
   """
 
-  @spec list_paths(args :: args()) :: response()
-  def list_paths(args \\ []) do
+  @spec list_paths(server :: server(), args :: args()) :: response()
+  def list_paths(server, args \\ []) do
     destination_asset = RequestParams.build_assets_params(args, :destination_asset)
 
     params =
@@ -69,8 +76,8 @@ defmodule Stellar.Horizon.PaymentPaths do
       |> Keyword.delete(:destination_asset)
       |> Keyword.merge(destination_asset)
 
-    :get
-    |> Request.new(@endpoint)
+    server
+    |> Request.new(:get, @endpoint)
     |> Request.add_query(params, extra_params: allowed_query_options(:list_paths))
     |> Request.perform()
     |> Request.results(as: Paths)
@@ -80,6 +87,8 @@ defmodule Stellar.Horizon.PaymentPaths do
   List Strict Receive Payment Paths
 
   ## Parameters
+
+    * `server`: The Horizon server to query.
 
     Using either `source_account` or `source_assets` as an argument is required for strict receive path payments.
     * `destination_asset`: `:native` or `[code: "destination_asset_code", issuer: "destination_asset_issuer"]`
@@ -93,33 +102,39 @@ defmodule Stellar.Horizon.PaymentPaths do
   ## Examples
 
       # list with `source_account`
-      iex> PaymentPaths.list_receive_paths(destination_asset: :native,
-                                           destination_amount: 5,
-                                           source_account: "GBTKSXOTFMC5HR25SNL76MOVQW7GA3F6CQEY622ASLUV4VMLITI6TCOO"
-                                          )
+      iex> PaymentPaths.list_receive_paths(
+        Stellar.Horizon.Server.testnet(),
+          destination_asset: :native,
+          destination_amount: 5,
+          source_account: "GBTKSXOTFMC5HR25SNL76MOVQW7GA3F6CQEY622ASLUV4VMLITI6TCOO"
+        )
       {:ok, %Paths{records: [%Path{}, ...]}}
 
 
       # list with `source_assets`
-      iex> PaymentPaths.list_receive_paths(destination_asset: :native,
-                                           destination_amount: 5,
-                                           source_assets: :native
-                                          )
+      iex> PaymentPaths.list_receive_paths(
+        Stellar.Horizon.Server.testnet(),
+          destination_asset: :native,
+          destination_amount: 5,
+          source_assets: :native
+        )
       {:ok, %Paths{records: [%Path{}, ...]}}
 
       # list with more options
-      iex> PaymentPaths.list_receive_paths(source_assets: "CNY:GAREELUB43IRHWEASCFBLKHURCGMHE5IF6XSE7EXDLACYHGRHM43RFOX",
-                                           destination_asset: [
-                                             code: "BB1",
-                                             issuer: "GD5J6HLF5666X4AZLTFTXLY46J5SW7EXRKBLEYPJP33S33MXZGV6CWFN"
-                                           ],
-                                           destination_amount: 5
-                                          )
+      iex> PaymentPaths.list_receive_paths(
+        Stellar.Horizon.Server.testnet(),
+          source_assets: "CNY:GAREELUB43IRHWEASCFBLKHURCGMHE5IF6XSE7EXDLACYHGRHM43RFOX",
+          destination_asset: [
+            code: "BB1",
+            issuer: "GD5J6HLF5666X4AZLTFTXLY46J5SW7EXRKBLEYPJP33S33MXZGV6CWFN"
+          ],
+          destination_amount: 5
+        )
       {:ok, %Paths{records: [%Path{}, ...]}}
   """
 
-  @spec list_receive_paths(args :: args()) :: response()
-  def list_receive_paths(args \\ []) do
+  @spec list_receive_paths(server :: server(), args :: args()) :: response()
+  def list_receive_paths(server, args \\ []) do
     destination_asset = RequestParams.build_assets_params(args, :destination_asset)
 
     params =
@@ -127,8 +142,8 @@ defmodule Stellar.Horizon.PaymentPaths do
       |> Keyword.delete(:destination_asset)
       |> Keyword.merge(destination_asset)
 
-    :get
-    |> Request.new(@endpoint, path: "strict-receive")
+    server
+    |> Request.new(:get, @endpoint, path: "strict-receive")
     |> Request.add_query(params, extra_params: allowed_query_options(:list_receive))
     |> Request.perform()
     |> Request.results(as: Paths)
@@ -138,43 +153,53 @@ defmodule Stellar.Horizon.PaymentPaths do
   List Strict Send Payment Paths
 
   ## Parameters
-      Using either `destination_account` or `destination_assets` as an argument is required for strict send path payments.
-      * `source_asset`: `:native` or `[code: "source_asset_code", issuer: "source_asset_issuer"]`
-      * `source_amount`: The amount of the source asset that should be sent.
+
+    * `server`: The Horizon server to query.
+
+    Using either `destination_account` or `destination_assets` as an argument is required for strict send path payments.
+    * `source_asset`: `:native` or `[code: "source_asset_code", issuer: "source_asset_issuer"]`
+    * `source_amount`: The amount of the source asset that should be sent.
 
   ## Options
-      * `destination_account`: The Stellar address of the reciever.
-      * `destination_assets`: A comma-separated list of assets that the recipient can receive.
+
+    * `destination_account`: The Stellar address of the reciever.
+    * `destination_assets`: A comma-separated list of assets that the recipient can receive.
 
   ## Examples
 
       * list with `destination_account`
-      iex> PaymentPaths.list_send_paths(source_asset: :native,
-                                        source_amount: 5,
-                                        destination_account: "GBTKSXOTFMC5HR25SNL76MOVQW7GA3F6CQEY622ASLUV4VMLITI6TCOO"
-                                      )
+      iex> PaymentPaths.list_send_paths(
+        Stellar.Horizon.Server.testnet(),
+          source_asset: :native,
+          source_amount: 5,
+          destination_account: "GBTKSXOTFMC5HR25SNL76MOVQW7GA3F6CQEY622ASLUV4VMLITI6TCOO"
+        )
       {:ok, %Paths{records: [%Path{}, ...]}}
 
       * list with `destination_assets`
-      iex> PaymentPaths.list_send_paths(source_asset: :native,
-                                        source_amount: 5,
-                                        destination_assets: "TEST:GA654JC6QLA3ZH4O5V7X5NPM7KEWHKRG5GJA4PETK4SOFBUJLCCN74KQ"
-                                      )
+      iex> PaymentPaths.list_send_paths(
+        Stellar.Horizon.Server.testnet(),
+          source_asset: :native,
+          source_amount: 5,
+          destination_assets: "TEST:GA654JC6QLA3ZH4O5V7X5NPM7KEWHKRG5GJA4PETK4SOFBUJLCCN74KQ"
+        )
       {:ok, %Paths{records: [%Path{}, ...]}}
 
       # list with more options
-      iex> PaymentPaths.list_send_paths(destination_account: "GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA",
-                                        source_asset: [
-                                          code: "BRL",
-                                          issuer: "GDVKY2GU2DRXWTBEYJJWSFXIGBZV6AZNBVVSUHEPZI54LIS6BA7DVVSP"
-                                        ],
-                                        source_amount: 400
-                                      )
+      iex> PaymentPaths.list_send_paths(
+        Stellar.Horizon.Server.testnet(),
+          destination_account: "GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA",
+          source_asset: [
+            code: "BRL",
+            issuer: "GDVKY2GU2DRXWTBEYJJWSFXIGBZV6AZNBVVSUHEPZI54LIS6BA7DVVSP"
+          ],
+          source_amount: 400
+        )
       {:ok, %Paths{records: [%Path{}, ...]}}
   """
 
-  @spec list_send_paths(args :: args()) :: response()
-  def list_send_paths(args \\ []) do
+  @spec list_send_paths(server :: server(), args :: args()) :: response()
+  def list_send_paths(server, args \\ []) do
     source_asset = RequestParams.build_assets_params(args, :source_asset)
 
     params =
@@ -182,8 +207,8 @@ defmodule Stellar.Horizon.PaymentPaths do
       |> Keyword.delete(:source_asset)
       |> Keyword.merge(source_asset)
 
-    :get
-    |> Request.new(@endpoint, path: "strict-send")
+    server
+    |> Request.new(:get, @endpoint, path: "strict-send")
     |> Request.add_query(params, extra_params: allowed_query_options(:list_send))
     |> Request.perform()
     |> Request.results(as: Paths)

--- a/lib/horizon/server.ex
+++ b/lib/horizon/server.ex
@@ -1,0 +1,28 @@
+defmodule Stellar.Horizon.Server do
+  @moduledoc """
+  Horizon Server URL configuration.
+  """
+
+  alias Stellar.Network
+
+  @type t :: %__MODULE__{url: String.t()}
+
+  defstruct [:url]
+
+  @spec new(url :: String.t()) :: t()
+  def new(url) when is_binary(url) do
+    %__MODULE__{url: url}
+  end
+
+  @spec public() :: t()
+  def public, do: new(Network.public_horizon_url())
+
+  @spec testnet() :: t()
+  def testnet, do: new(Network.testnet_horizon_url())
+
+  @spec futurenet() :: t()
+  def futurenet, do: new(Network.futurenet_horizon_url())
+
+  @spec local() :: t()
+  def local, do: new(Network.local_horizon_url())
+end

--- a/lib/horizon/trade_aggregations.ex
+++ b/lib/horizon/trade_aggregations.ex
@@ -8,8 +8,9 @@ defmodule Stellar.Horizon.TradeAggregations do
   Horizon API reference: https://developers.stellar.org/api/aggregations/trade-aggregations/
   """
 
-  alias Stellar.Horizon.{Error, Request, RequestParams, TradeAggregation}
+  alias Stellar.Horizon.{Error, Request, RequestParams, TradeAggregation, Server}
 
+  @type server :: Server.t()
   @type args :: Keyword.t()
   @type resource :: TradeAggregation.t()
   @type response :: {:ok, resource()} | {:error, Error.t()}
@@ -21,6 +22,7 @@ defmodule Stellar.Horizon.TradeAggregations do
 
     ## Parameters
 
+      * `server`: The Horizon server to query.
       * `base_asset`: `:native` or `[code: "base_asset_code", issuer: "base_asset_issuer"]`
       * `counter_asset`: `:native` or `[code: "counter_asset_code", issuer: "counter_asset_issuer"]`
       * `resolution`: The segment duration represented as milliseconds.
@@ -35,30 +37,37 @@ defmodule Stellar.Horizon.TradeAggregations do
 
     ## Examples
 
-        iex> TradeAggregations.list_trade_aggregations(base_asset: :native, counter_asset: :native, resolution: "60000")
+        iex> TradeAggregations.list_trade_aggregations(
+          Stellar.Horizon.Server.testnet(),
+           base_asset: :native,
+           counter_asset: :native,
+           resolution: "60000"
+          )
         {:ok, %Collection{records: [%TradeAggregation{}, ...]}}
 
-        iex> TradeAggregations.list_trade_aggregations(base_asset: :native,
-                                                      counter_asset: [
-                                                        code: "EURT",
-                                                        issuer: "GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S"
-                                                      ],
-                                                      resolution: "3600000",
-                                                      start_time: "1582156800000",
-                                                      end_time: "1582178400000"
-                                                      )
+        iex> TradeAggregations.list_trade_aggregations(
+          Stellar.Horizon.Server.testnet(),
+           base_asset: :native,
+           counter_asset: [
+             code: "EURT",
+             issuer: "GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S"
+           ],
+           resolution: "3600000",
+           start_time: "1582156800000",
+           end_time: "1582178400000"
+          )
         {:ok, %Collection{records: [%TradeAggregation{}, ...]}}
   """
 
-  @spec list_trade_aggregations(args :: args()) :: response()
-  def list_trade_aggregations(args \\ []) do
+  @spec list_trade_aggregations(server :: server(), args :: args()) :: response()
+  def list_trade_aggregations(server, args \\ []) do
     params = resolve_params(args)
 
-    :get
-    |> Request.new(@endpoint)
+    server
+    |> Request.new(:get, @endpoint)
     |> Request.add_query(params, extra_params: allowed_query_options())
     |> Request.perform()
-    |> Request.results(collection: {TradeAggregation, &list_trade_aggregations/1})
+    |> Request.results(collection: {TradeAggregation, &list_trade_aggregations(server, &1)})
   end
 
   @spec resolve_params(args :: args()) :: Keyword.t()

--- a/lib/horizon/trades.ex
+++ b/lib/horizon/trades.ex
@@ -8,8 +8,10 @@ defmodule Stellar.Horizon.Trades do
   Horizon API reference: https://developers.stellar.org/api/resources/trades/
   """
 
-  alias Stellar.Horizon.{Collection, Error, Request, Trade, RequestParams}
+  alias Stellar.Horizon.{Collection, Error, Request, Trade, RequestParams, Server}
 
+
+  @type server :: Server.t()
   @type options :: Keyword.t()
   @type resource :: Trade.t() | Collection.t()
   @type response :: {:ok, resource()} | {:error, Error.t()}
@@ -31,15 +33,16 @@ defmodule Stellar.Horizon.Trades do
 
   ## Examples
 
-      iex> Trades.all(limit: 20, order: :asc)
+      iex> Trades.all(Stellar.Horizon.Server.testnet(), limit: 20, order: :asc)
       {:ok, %Collection{records: [%Trade{}, ...]}}
 
       # list by offer_id
-      iex> Trades.all(offer_id: 165563085)
+      iex> Trades.all(Stellar.Horizon.Server.testnet(), offer_id: 165563085)
       {:ok, %Collection{records: [%Trade{}, ...]}}
 
       # list by specific orderbook
       iex> Trades.all(
+        Stellar.Horizon.Server.testnet(),
         base_asset: [
           code: "TEST",
           issuer: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD"
@@ -50,11 +53,11 @@ defmodule Stellar.Horizon.Trades do
       {:ok, %Collection{records: [%Trade{}, ...]}}
 
       # list by trade_type
-      iex> Trades.all(trade_type: "liquidity_pools", limit: 20)
+      iex> Trades.all(Stellar.Horizon.Server.testnet(), trade_type: "liquidity_pools", limit: 20)
       {:ok, %Collection{records: [%Trade{}, ...]}}
   """
-  @spec all(options :: options()) :: response()
-  def all(options \\ []) do
+  @spec all(server :: server(), options :: options()) :: response()
+  def all(server, options \\ []) do
     base_asset = RequestParams.build_assets_params(options, :base_asset)
     counter_asset = RequestParams.build_assets_params(options, :counter_asset)
 
@@ -63,11 +66,11 @@ defmodule Stellar.Horizon.Trades do
       |> Keyword.merge(base_asset)
       |> Keyword.merge(counter_asset)
 
-    :get
-    |> Request.new(@endpoint)
+    server
+    |> Request.new(:get, @endpoint)
     |> Request.add_query(params, extra_params: allowed_query_options())
     |> Request.perform()
-    |> Request.results(collection: {Trade, &all/1})
+    |> Request.results(collection: {Trade, &all(server, &1)})
   end
 
   @spec allowed_query_options() :: list()

--- a/lib/horizon/trades.ex
+++ b/lib/horizon/trades.ex
@@ -10,7 +10,6 @@ defmodule Stellar.Horizon.Trades do
 
   alias Stellar.Horizon.{Collection, Error, Request, Trade, RequestParams, Server}
 
-
   @type server :: Server.t()
   @type options :: Keyword.t()
   @type resource :: Trade.t() | Collection.t()

--- a/lib/horizon/transactions.ex
+++ b/lib/horizon/transactions.ex
@@ -12,8 +12,9 @@ defmodule Stellar.Horizon.Transactions do
   Horizon API reference: https://developers.stellar.org/api/resources/transactions/
   """
 
-  alias Stellar.Horizon.{Collection, Effect, Error, Operation, Transaction, Request}
+  alias Stellar.Horizon.{Collection, Effect, Error, Operation, Transaction, Request, Server}
 
+  @type server :: Server.t()
   @type hash :: String.t()
   @type options :: Keyword.t()
   @type resource :: Transaction.t() | Collection.t()
@@ -25,17 +26,18 @@ defmodule Stellar.Horizon.Transactions do
   Creates a transaction to the Stellar network.
 
   ## Parameters:
+    * `server`: The Horizon server to query.
     * `tx`: The base64-encoded XDR of the transaction.
 
   ## Examples
 
-      iex> Transactions.create("AAAAAgAAAACQcEK2yfQA9CHrX+2UMkRIb/1wzltKqHpbdIcJbp+b/QAAAGQAAiEYAAAAAQAAAAEAAAAAAAAAAAAAAABgXP3QAAAAAQAAABBUZXN0IFRyYW5zYWN0aW9uAAAAAQAAAAAAAAABAAAAAJBwQrbJ9AD0Ietf7ZQyREhv/XDOW0qoelt0hwlun5v9AAAAAAAAAAAF9eEAAAAAAAAAAAFun5v9AAAAQKdJnG8QRiv9xGp1Oq7ACv/xR2BnNqjfUHrGNua7m4tWbrun3+GmAj6ca3xz+4ZppWRTbvTUcCxvpbHERZ85QgY=")
+      iex> Transactions.create(Stellar.Horizon.Server.testnet(), "AAAAAgAAAACQcEK2yfQA9CHrX+2UMkRIb/1wzltKqHpbdIcJbp+b/QAAAGQAAiEYAAAAAQAAAAEAAAAAAAAAAAAAAABgXP3QAAAAAQAAABBUZXN0IFRyYW5zYWN0aW9uAAAAAQAAAAAAAAABAAAAAJBwQrbJ9AD0Ietf7ZQyREhv/XDOW0qoelt0hwlun5v9AAAAAAAAAAAF9eEAAAAAAAAAAAFun5v9AAAAQKdJnG8QRiv9xGp1Oq7ACv/xR2BnNqjfUHrGNua7m4tWbrun3+GmAj6ca3xz+4ZppWRTbvTUcCxvpbHERZ85QgY=")
       {:ok, %Transaction{}}
   """
-  @spec create(base64_envelope :: String.t()) :: response()
-  def create(base64_envelope) do
-    :post
-    |> Request.new(@endpoint)
+  @spec create(server :: server(), base64_envelope :: String.t()) :: response()
+  def create(server, base64_envelope) do
+    server
+    |> Request.new(:post, @endpoint)
     |> Request.add_headers([{"Content-Type", "application/x-www-form-urlencoded"}])
     |> Request.add_body(tx: base64_envelope)
     |> Request.perform()
@@ -46,23 +48,27 @@ defmodule Stellar.Horizon.Transactions do
   Retrieves information of a specific transaction.
 
   ## Parameters:
+    * `server`: The Horizon server to query.
     * `hash`: A hex-encoded SHA-256 hash of this transaction’s XDR-encoded form.
 
   ## Examples
 
-      iex> Transactions.retrieve("5ebd5c0af4385500b53dd63b0ef5f6e8feef1a7e1c86989be3cdcce825f3c0cc")
+      iex> Transactions.retrieve(Stellar.Horizon.Server.testnet(), "5ebd5c0af4385500b53dd63b0ef5f6e8feef1a7e1c86989be3cdcce825f3c0cc")
       {:ok, %Transaction{}}
   """
-  @spec retrieve(hash :: hash()) :: response()
-  def retrieve(hash) do
-    :get
-    |> Request.new(@endpoint, path: hash)
+  @spec retrieve(server :: server(), hash :: hash()) :: response()
+  def retrieve(server, hash) do
+    server
+    |> Request.new(:get, @endpoint, path: hash)
     |> Request.perform()
     |> Request.results(as: Transaction)
   end
 
   @doc """
   Lists all successful transactions.
+
+  ## Parameters:
+    * `server`: The Horizon server to query.
 
   ## Options
 
@@ -73,26 +79,27 @@ defmodule Stellar.Horizon.Transactions do
 
   ## Examples
 
-      iex> Transactions.all(limit: 10, order: :asc)
+      iex> Transactions.all(Stellar.Horizon.Server.testnet(), limit: 10, order: :asc)
       {:ok, %Collection{records: [%Transaction{}, ...]}}
 
       # include failed
-      iex> Transactions.all(limit: 10, include_failed: true)
+      iex> Transactions.all(Stellar.Horizon.Server.testnet(), limit: 10, include_failed: true)
       {:ok, %Collection{records: [%Transaction{}, ...]}}
   """
-  @spec all(options :: options()) :: response()
-  def all(options \\ []) do
-    :get
-    |> Request.new(@endpoint)
+  @spec all(server :: server(), options :: options()) :: response()
+  def all(server, options \\ []) do
+    server
+    |> Request.new(:get, @endpoint)
     |> Request.add_query(options, extra_params: [:include_failed])
     |> Request.perform()
-    |> Request.results(collection: {Transaction, &all/1})
+    |> Request.results(collection: {Transaction, &all(server, &1)})
   end
 
   @doc """
   Lists the effects of a specific transaction.
 
   ## Parameters
+    * `server`: The Horizon server to query.
     * `hash`: A hex-encoded SHA-256 hash of this transaction’s XDR-encoded form.
 
   ## Options
@@ -102,22 +109,23 @@ defmodule Stellar.Horizon.Transactions do
 
   ## Examples
 
-      iex> Transactions.list_effects("6b983a4e0dc3c04f4bd6b9037c55f70a09c434dfd01492be1077cf7ea68c2e4a", limit: 20)
+      iex> Transactions.list_effects(Stellar.Horizon.Server.testnet(), "6b983a4e0dc3c04f4bd6b9037c55f70a09c434dfd01492be1077cf7ea68c2e4a", limit: 20)
       {:ok, %Collection{records: [%Effect{}, ...]}}
   """
-  @spec list_effects(hash :: hash(), options :: options()) :: response()
-  def list_effects(hash, options \\ []) do
-    :get
-    |> Request.new(@endpoint, path: hash, segment: "effects")
+  @spec list_effects(server :: server(), hash :: hash(), options :: options()) :: response()
+  def list_effects(server, hash, options \\ []) do
+    server
+    |> Request.new(:get, @endpoint, path: hash, segment: "effects")
     |> Request.add_query(options)
     |> Request.perform()
-    |> Request.results(collection: {Effect, &list_effects(hash, &1)})
+    |> Request.results(collection: {Effect, &list_effects(server, hash, &1)})
   end
 
   @doc """
   Lists successful operations for a specific transaction.
 
   ## Parameters
+    * `server`: The Horizon server to query.
     * `hash`: A hex-encoded SHA-256 hash of this transaction’s XDR-encoded form.
 
   ## Options
@@ -129,19 +137,19 @@ defmodule Stellar.Horizon.Transactions do
 
   ## Examples
 
-      iex> Transactions.list_operations("6b983a4e0dc3c04f4bd6b9037c55f70a09c434dfd01492be1077cf7ea68c2e4a", limit: 20)
+      iex> Transactions.list_operations(Stellar.Horizon.Server.testnet(), "6b983a4e0dc3c04f4bd6b9037c55f70a09c434dfd01492be1077cf7ea68c2e4a", limit: 20)
       {:ok, %Collection{records: [%Operation{}, ...]}}
 
       # join transactions
-      iex> Transactions.list_operations("6b983a4e0dc3c04f4bd6b9037c55f70a09c434dfd01492be1077cf7ea68c2e4a", join: "transactions")
+      iex> Transactions.list_operations(Stellar.Horizon.Server.testnet(), "6b983a4e0dc3c04f4bd6b9037c55f70a09c434dfd01492be1077cf7ea68c2e4a", join: "transactions")
       {:ok, %Collection{records: [%Operation{transaction: %Transaction{}}, ...]}}
   """
-  @spec list_operations(hash :: hash(), options :: options()) :: response()
-  def list_operations(hash, options \\ []) do
-    :get
-    |> Request.new(@endpoint, path: hash, segment: "operations")
+  @spec list_operations(server :: server(), hash :: hash(), options :: options()) :: response()
+  def list_operations(server, hash, options \\ []) do
+    server
+    |> Request.new(:get, @endpoint, path: hash, segment: "operations")
     |> Request.add_query(options, extra_params: [:include_failed, :join])
     |> Request.perform()
-    |> Request.results(collection: {Operation, &list_operations(hash, &1)})
+    |> Request.results(collection: {Operation, &list_operations(server, hash, &1)})
   end
 end

--- a/lib/util/network.ex
+++ b/lib/util/network.ex
@@ -4,45 +4,42 @@ defmodule Stellar.Network do
   """
 
   @passphrases [
+    public: "Public Global Stellar Network ; September 2015",
     test: "Test SDF Network ; September 2015",
     future: "Test SDF Future Network ; October 2022",
-    public: "Public Global Stellar Network ; September 2015",
-    local: "Standalone Network ; February 2017"
+    standalone: "Standalone Network ; February 2017"
   ]
 
-  @public_passphrase "Public Global Stellar Network ; September 2015"
-  @testnet_passphrase "Test SDF Network ; September 2015"
-  @futurenet_passphrase "Test SDF Future Network ; October 2022"
-  @standalone_passphrase "Standalone Network ; February 2017"
-
-  @public_horizon_url "https://horizon.stellar.org"
-  @testnet_horizon_url "https://horizon-testnet.stellar.org"
-  @futurenet_horizon_url "https://horizon-futurenet.stellar.org"
-  @local_horizon_url "http://localhost:8000"
+  @horizon_urls [
+    public: "https://horizon.stellar.org",
+    test: "https://horizon-testnet.stellar.org",
+    future: "https://horizon-futurenet.stellar.org",
+    local: "http://localhost:8000"
+  ]
 
   @spec public_passphrase() :: String.t()
-  def public_passphrase, do: @public_passphrase
+  def public_passphrase, do: @passphrases[:public]
 
   @spec testnet_passphrase() :: String.t()
-  def testnet_passphrase, do: @testnet_passphrase
+  def testnet_passphrase, do: @passphrases[:test]
 
   @spec futurenet_passphrase() :: String.t()
-  def futurenet_passphrase, do: @futurenet_passphrase
+  def futurenet_passphrase, do: @passphrases[:future]
 
   @spec standalone_passphrase() :: String.t()
-  def standalone_passphrase, do: @standalone_passphrase
+  def standalone_passphrase, do: @passphrases[:standalone]
 
   @spec public_horizon_url() :: String.t()
-  def public_horizon_url, do: @public_horizon_url
+  def public_horizon_url, do: @horizon_urls[:public]
 
   @spec testnet_horizon_url() :: String.t()
-  def testnet_horizon_url, do: @testnet_horizon_url
+  def testnet_horizon_url, do: @horizon_urls[:test]
 
   @spec futurenet_horizon_url() :: String.t()
-  def futurenet_horizon_url, do: @futurenet_horizon_url
+  def futurenet_horizon_url, do: @horizon_urls[:future]
 
   @spec local_horizon_url() :: String.t()
-  def local_horizon_url, do: @local_horizon_url
+  def local_horizon_url, do: @horizon_urls[:local]
 
   @spec passphrase() :: String.t()
   def passphrase do

--- a/lib/util/network.ex
+++ b/lib/util/network.ex
@@ -10,18 +10,39 @@ defmodule Stellar.Network do
     local: "Standalone Network ; February 2017"
   ]
 
-  @base_urls [
-    test: "https://horizon-testnet.stellar.org",
-    future: "https://horizon-futurenet.stellar.org",
-    public: "https://horizon.stellar.org",
-    local: "http://localhost:8000"
-  ]
+  @public_passphrase "Public Global Stellar Network ; September 2015"
+  @testnet_passphrase "Test SDF Network ; September 2015"
+  @futurenet_passphrase "Test SDF Future Network ; October 2022"
+  @standalone_passphrase "Standalone Network ; February 2017"
 
-  @spec base_url() :: String.t()
-  def base_url do
-    default = @base_urls[:test]
-    Keyword.get(@base_urls, current(), default)
-  end
+  @public_horizon_url "https://horizon.stellar.org"
+  @testnet_horizon_url "https://horizon-testnet.stellar.org"
+  @futurenet_horizon_url "https://horizon-futurenet.stellar.org"
+  @local_horizon_url "http://localhost:8000"
+
+  @spec public_passphrase() :: String.t()
+  def public_passphrase, do: @public_passphrase
+
+  @spec testnet_passphrase() :: String.t()
+  def testnet_passphrase, do: @testnet_passphrase
+
+  @spec futurenet_passphrase() :: String.t()
+  def futurenet_passphrase, do: @futurenet_passphrase
+
+  @spec standalone_passphrase() :: String.t()
+  def standalone_passphrase, do: @standalone_passphrase
+
+  @spec public_horizon_url() :: String.t()
+  def public_horizon_url, do: @public_horizon_url
+
+  @spec testnet_horizon_url() :: String.t()
+  def testnet_horizon_url, do: @testnet_horizon_url
+
+  @spec futurenet_horizon_url() :: String.t()
+  def futurenet_horizon_url, do: @futurenet_horizon_url
+
+  @spec local_horizon_url() :: String.t()
+  def local_horizon_url, do: @local_horizon_url
 
   @spec passphrase() :: String.t()
   def passphrase do

--- a/mix.lock
+++ b/mix.lock
@@ -24,6 +24,6 @@
   "nimble_parsec": {:hex, :nimble_parsec, "1.3.1", "2c54013ecf170e249e9291ed0a62e5832f70a476c61da16f6aac6dca0189f2af", [:mix], [], "hexpm", "2682e3c0b2eb58d90c6375fc0cc30bc7be06f365bf72608804fb9cffa5e1b167"},
   "parse_trans": {:hex, :parse_trans, "3.3.1", "16328ab840cc09919bd10dab29e431da3af9e9e7e7e6f0089dd5a2d2820011d8", [:rebar3], [], "hexpm", "07cd9577885f56362d414e8c4c4e6bdf10d43a8767abb92d24cbe8b24c54888b"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.7", "354c321cf377240c7b8716899e182ce4890c5938111a1296add3ec74cf1715df", [:make, :mix, :rebar3], [], "hexpm", "fe4c190e8f37401d30167c8c405eda19469f34577987c76dde613e838bbc67f8"},
-  "stellar_base": {:git, "https://github.com/kommitters/stellar_base.git", "849841e65575201643d587014752326374494d76", [branch: "v0.15"]},
+  "stellar_base": {:hex, :stellar_base, "0.15.0", "893b7ee194aa0c732fbc16be431418d8269dc0221b70ecdb6320705540ba395f", [:mix], [{:castore, "~> 1.0", [hex: :castore, repo: "hexpm", optional: false]}, {:crc, "~> 0.10.0", [hex: :crc, repo: "hexpm", optional: false]}, {:elixir_xdr, "~> 0.3", [hex: :elixir_xdr, repo: "hexpm", optional: false]}], "hexpm", "411aba27c89c03ac237457c171740428aef6f958aeebb4811723436e9105dc60"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }

--- a/test/horizon/accounts_test.exs
+++ b/test/horizon/accounts_test.exs
@@ -379,7 +379,8 @@ defmodule Stellar.Horizon.AccountsTest do
   end
 
   test "data/1", %{account_id: account_id} do
-    {:ok, %Account.Data{value: "QkdFR0ZFVEVHRUhIRUVI"}} = Accounts.data(Server.testnet(), account_id, "NFT")
+    {:ok, %Account.Data{value: "QkdFR0ZFVEVHRUhIRUVI"}} =
+      Accounts.data(Server.testnet(), account_id, "NFT")
   end
 
   test "paginate_collection prev" do

--- a/test/horizon/accounts_test.exs
+++ b/test/horizon/accounts_test.exs
@@ -166,7 +166,8 @@ defmodule Stellar.Horizon.AccountsTest do
     Offer,
     Operation,
     Trade,
-    Transaction
+    Transaction,
+    Server
   }
 
   alias Stellar.Horizon.Operation.{CreateAccount, Payment, SetOptions}
@@ -225,11 +226,11 @@ defmodule Stellar.Horizon.AccountsTest do
          low_threshold: 1,
          med_threshold: 2
        }
-     }} = Accounts.retrieve(account_id)
+     }} = Accounts.retrieve(Server.testnet(), account_id)
   end
 
   test "fetch_next_sequence_number/1", %{account_id: account_id} do
-    {:ok, 17_218_523_889_681} = Accounts.fetch_next_sequence_number(account_id)
+    {:ok, 17_218_523_889_681} = Accounts.fetch_next_sequence_number(Server.testnet(), account_id)
   end
 
   test "all/1" do
@@ -240,7 +241,7 @@ defmodule Stellar.Horizon.AccountsTest do
          %Account{id: "GAP2KHWUMOHY7IO37UJY7SEBIITJIDZS5DRIIQRPEUT4VUKHZQGIRWS4"},
          %Account{id: "GALPCCZN4YXA3YMJHKL6CVIECKPLJJCTVMSNYWBTKJW4K5HQLYLDMZTB"}
        ]
-     }} = Accounts.all()
+     }} = Accounts.all(Server.testnet())
   end
 
   test "list_effects/1", %{account_id: account_id} do
@@ -253,7 +254,7 @@ defmodule Stellar.Horizon.AccountsTest do
          %Effect{type: "contract_debited", created_at: ~U[2023-10-10 15:53:13Z]},
          %Effect{type: "contract_credited", created_at: ~U[2023-10-10 15:52:40Z]}
        ]
-     }} = Accounts.list_effects(account_id, limit: 5)
+     }} = Accounts.list_effects(Server.testnet(), account_id, limit: 5)
   end
 
   test "list_offers/1", %{account_id: account_id} do
@@ -279,7 +280,7 @@ defmodule Stellar.Horizon.AccountsTest do
            amount: "24.9999990"
          }
        ]
-     }} = Accounts.list_offers(account_id)
+     }} = Accounts.list_offers(Server.testnet(), account_id)
   end
 
   test "list_trades/1", %{account_id: account_id} do
@@ -302,7 +303,7 @@ defmodule Stellar.Horizon.AccountsTest do
            base_amount: "748.5338945"
          }
        ]
-     }} = Accounts.list_trades(account_id)
+     }} = Accounts.list_trades(Server.testnet(), account_id)
   end
 
   test "list_transactions/1", %{account_id: account_id} do
@@ -325,7 +326,7 @@ defmodule Stellar.Horizon.AccountsTest do
            ledger: 7855
          }
        ]
-     }} = Accounts.list_transactions(account_id, limit: 3, order: :asc)
+     }} = Accounts.list_transactions(Server.testnet(), account_id, limit: 3, order: :asc)
   end
 
   test "list_operations/1", %{account_id: account_id} do
@@ -351,7 +352,7 @@ defmodule Stellar.Horizon.AccountsTest do
            type_i: 0
          }
        ]
-     }} = Accounts.list_operations(account_id, limit: 3, order: :desc)
+     }} = Accounts.list_operations(Server.testnet(), account_id, limit: 3, order: :desc)
   end
 
   test "list_payments/1", %{account_id: account_id} do
@@ -374,22 +375,22 @@ defmodule Stellar.Horizon.AccountsTest do
            type_i: 1
          }
        ]
-     }} = Accounts.list_payments(account_id, limit: 3)
+     }} = Accounts.list_payments(Server.testnet(), account_id, limit: 3)
   end
 
   test "data/1", %{account_id: account_id} do
-    {:ok, %Account.Data{value: "QkdFR0ZFVEVHRUhIRUVI"}} = Accounts.data(account_id, "NFT")
+    {:ok, %Account.Data{value: "QkdFR0ZFVEVHRUhIRUVI"}} = Accounts.data(Server.testnet(), account_id, "NFT")
   end
 
   test "paginate_collection prev" do
-    {:ok, %Collection{prev: paginate_prev_fn}} = Accounts.all(limit: 3)
+    {:ok, %Collection{prev: paginate_prev_fn}} = Accounts.all(Server.testnet(), limit: 3)
     paginate_prev_fn.()
 
     assert_receive({:paginated, :prev})
   end
 
   test "paginate_collection next" do
-    {:ok, %Collection{next: paginate_next_fn}} = Accounts.all(limit: 3)
+    {:ok, %Collection{next: paginate_next_fn}} = Accounts.all(Server.testnet(), limit: 3)
     paginate_next_fn.()
 
     assert_receive({:paginated, :next})
@@ -402,7 +403,7 @@ defmodule Stellar.Horizon.AccountsTest do
        status_code: 404,
        title: "Resource Missing",
        type: "https://stellar.org/horizon-errors/not_found"
-     }} = Accounts.retrieve("not_found")
+     }} = Accounts.retrieve(Server.testnet(), "not_found")
   end
 
   test "fetch_next_sequence_number error" do
@@ -412,6 +413,6 @@ defmodule Stellar.Horizon.AccountsTest do
        status_code: 404,
        title: "Resource Missing",
        type: "https://stellar.org/horizon-errors/not_found"
-     }} = Accounts.fetch_next_sequence_number("not_found")
+     }} = Accounts.fetch_next_sequence_number(Server.testnet(), "not_found")
   end
 end

--- a/test/horizon/assets_test.exs
+++ b/test/horizon/assets_test.exs
@@ -69,7 +69,7 @@ defmodule Stellar.Horizon.AssetsTest do
   use ExUnit.Case
 
   alias Stellar.Horizon.Client.CannedAssetRequests
-  alias Stellar.Horizon.{Asset, Assets, Collection, Error}
+  alias Stellar.Horizon.{Asset, Assets, Collection, Error, Server}
 
   setup do
     Application.put_env(:stellar_sdk, :http_client, CannedAssetRequests)
@@ -104,7 +104,7 @@ defmodule Stellar.Horizon.AssetsTest do
            asset_issuer: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD"
          }
        ]
-     }} = Assets.all(limit: 3)
+     }} = Assets.all(Server.testnet(), limit: 3)
   end
 
   test "list_by_asset_code/2", %{asset_code: asset_code} do
@@ -118,7 +118,7 @@ defmodule Stellar.Horizon.AssetsTest do
          },
          _asset2
        ]
-     }} = Assets.list_by_asset_code(asset_code, limit: 3)
+     }} = Assets.list_by_asset_code(Server.testnet(), asset_code, limit: 3)
   end
 
   test "list_by_asset_issuer/2", %{asset_issuer: asset_issuer} do
@@ -135,18 +135,18 @@ defmodule Stellar.Horizon.AssetsTest do
            asset_issuer: "GCXMWUAUF37IWOOV2FRDKWEX3O2IHLM2FYH4WPI4PYUKAIFQEUU5X3TD"
          }
        ]
-     }} = Assets.list_by_asset_issuer(asset_issuer, limit: 3)
+     }} = Assets.list_by_asset_issuer(Server.testnet(), asset_issuer, limit: 3)
   end
 
   test "paginate_collection prev" do
-    {:ok, %Collection{prev: paginate_prev_fn}} = Assets.all(limit: 3)
+    {:ok, %Collection{prev: paginate_prev_fn}} = Assets.all(Server.testnet(), limit: 3)
     paginate_prev_fn.()
 
     assert_receive({:paginated, :prev})
   end
 
   test "paginate_collection next" do
-    {:ok, %Collection{next: paginate_next_fn}} = Assets.all(limit: 3)
+    {:ok, %Collection{next: paginate_next_fn}} = Assets.all(Server.testnet(), limit: 3)
     paginate_next_fn.()
 
     assert_receive({:paginated, :next})
@@ -160,6 +160,6 @@ defmodule Stellar.Horizon.AssetsTest do
        status_code: 400,
        title: "Bad Request",
        type: "https://stellar.org/horizon-errors/bad_request"
-     }} = Assets.all(cursor: "error")
+     }} = Assets.all(Server.testnet(), cursor: "error")
   end
 end

--- a/test/horizon/claimable_balances_test.exs
+++ b/test/horizon/claimable_balances_test.exs
@@ -131,7 +131,8 @@ defmodule Stellar.Horizon.ClaimableBalancesTest do
     Collection,
     Error,
     Operation,
-    Transaction
+    Transaction,
+    Server
   }
 
   alias Stellar.Horizon.Operation.{CreateAccount, Payment, SetOptions}
@@ -178,7 +179,7 @@ defmodule Stellar.Horizon.ClaimableBalancesTest do
        last_modified_time: ~U[2020-02-26 19:29:16Z],
        paging_token: "00000000929b20b72e5890ab51c24f1cc46fa01c4f318d8d33367d24dd614cfdf5491072",
        sponsor: nil
-     }} = ClaimableBalances.retrieve(claimable_balance_id)
+     }} = ClaimableBalances.retrieve(Server.testnet(), claimable_balance_id)
   end
 
   test "all/1" do
@@ -235,7 +236,7 @@ defmodule Stellar.Horizon.ClaimableBalancesTest do
            sponsor: "GB3A3CK64CZDZ63FZTVI3OKK7ZCD75YQCPA2EKHPDFD6ABKEQ3ESTWVV"
          }
        ]
-     }} = ClaimableBalances.all()
+     }} = ClaimableBalances.all(Server.testnet())
   end
 
   test "list_by_sponsor/2" do
@@ -247,6 +248,7 @@ defmodule Stellar.Horizon.ClaimableBalancesTest do
        ]
      }} =
       ClaimableBalances.list_by_sponsor(
+        Server.testnet(),
         "GBXISGJYYKE6RUO6L6KXBUJ7FJU4CWF647FLQAT3TZ2Q47IZHXFNYKYH"
       )
   end
@@ -262,6 +264,7 @@ defmodule Stellar.Horizon.ClaimableBalancesTest do
        ]
      }} =
       ClaimableBalances.list_by_claimant(
+        Server.testnet(),
         "GATBAGTTQLQ4VKZMXLINLS6M4F2PEXMAZCK5ZE5ES4B6A2DXNGCFRX54"
       )
   end
@@ -275,6 +278,7 @@ defmodule Stellar.Horizon.ClaimableBalancesTest do
        ]
      }} =
       ClaimableBalances.list_by_asset(
+        Server.testnet(),
         "BTCN:GDGHQTCJ3SGFBWBHJGVRUFBRLZGS5VS52HEDH4GVPX5GZRJQAOW7ZM37"
       )
   end
@@ -296,7 +300,11 @@ defmodule Stellar.Horizon.ClaimableBalancesTest do
            ledger: 7855
          }
        ]
-     }} = ClaimableBalances.list_transactions(claimable_balance_id, limit: 3, order: :asc)
+     }} =
+      ClaimableBalances.list_transactions(Server.testnet(), claimable_balance_id,
+        limit: 3,
+        order: :asc
+      )
   end
 
   test "list_operations/1", %{claimable_balance_id: claimable_balance_id} do
@@ -319,18 +327,22 @@ defmodule Stellar.Horizon.ClaimableBalancesTest do
            type_i: 0
          }
        ]
-     }} = ClaimableBalances.list_operations(claimable_balance_id, limit: 3, order: :desc)
+     }} =
+      ClaimableBalances.list_operations(Server.testnet(), claimable_balance_id,
+        limit: 3,
+        order: :desc
+      )
   end
 
   test "paginate_collection prev" do
-    {:ok, %Collection{prev: paginate_prev_fn}} = ClaimableBalances.all(limit: 3)
+    {:ok, %Collection{prev: paginate_prev_fn}} = ClaimableBalances.all(Server.testnet(), limit: 3)
     paginate_prev_fn.()
 
     assert_receive({:paginated, :prev})
   end
 
   test "paginate_collection next" do
-    {:ok, %Collection{next: paginate_next_fn}} = ClaimableBalances.all(limit: 3)
+    {:ok, %Collection{next: paginate_next_fn}} = ClaimableBalances.all(Server.testnet(), limit: 3)
     paginate_next_fn.()
 
     assert_receive({:paginated, :next})
@@ -343,6 +355,6 @@ defmodule Stellar.Horizon.ClaimableBalancesTest do
        status_code: 404,
        title: "Resource Missing",
        type: "https://stellar.org/horizon-errors/not_found"
-     }} = ClaimableBalances.retrieve("not_found")
+     }} = ClaimableBalances.retrieve(Server.testnet(), "not_found")
   end
 end

--- a/test/horizon/client/default_test.exs
+++ b/test/horizon/client/default_test.exs
@@ -91,7 +91,6 @@ defmodule Stellar.Horizon.Client.DefaultTest do
     test "not_acceptable", %{server: server} do
       {:error, %Error{title: "Not Acceptable", status_code: 406}} =
         Default.request(server, :get, "/accounts/id.html")
-
     end
 
     test "before_history", %{server: server} do

--- a/test/horizon/client_test.exs
+++ b/test/horizon/client_test.exs
@@ -4,7 +4,7 @@ defmodule Stellar.Horizon.Client.CannedClientImpl do
   @behaviour Stellar.Horizon.Client.Spec
 
   @impl true
-  def request(_method, _path, _headers, _body, _opts) do
+  def request(_server, _method, _path, _headers, _body, _opts) do
     send(self(), {:requested, 200})
     {:ok, 200, [], nil}
   end
@@ -13,7 +13,7 @@ end
 defmodule Stellar.Horizon.ClientTest do
   use ExUnit.Case
 
-  alias Stellar.Horizon.Client
+  alias Stellar.Horizon.{Client, Server}
   alias Stellar.Horizon.Client.CannedClientImpl
 
   setup do
@@ -25,7 +25,7 @@ defmodule Stellar.Horizon.ClientTest do
   end
 
   test "request/5" do
-    Client.request(:get, "/accounts/GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XBNXCW4BVA")
+    Client.request(Server.testnet(), :get, "/accounts/GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XBNXCW4BVA")
     assert_receive({:requested, 200})
   end
 end

--- a/test/horizon/effects_test.exs
+++ b/test/horizon/effects_test.exs
@@ -55,7 +55,7 @@ defmodule Stellar.Horizon.EffectsTest do
   use ExUnit.Case
 
   alias Stellar.Horizon.Client.CannedEffectRequests
-  alias Stellar.Horizon.{Collection, Error, Effect, Effects}
+  alias Stellar.Horizon.{Collection, Error, Effect, Effects, Server}
 
   setup do
     Application.put_env(:stellar_sdk, :http_client, CannedEffectRequests)
@@ -127,18 +127,18 @@ defmodule Stellar.Horizon.EffectsTest do
            created_at: ~U[2023-10-10 15:52:40Z]
          }
        ]
-     }} = Effects.all(limit: 3)
+     }} = Effects.all(Server.testnet(), limit: 3)
   end
 
   test "paginate_collection prev" do
-    {:ok, %Collection{prev: paginate_prev_fn}} = Effects.all(limit: 3)
+    {:ok, %Collection{prev: paginate_prev_fn}} = Effects.all(Server.testnet(), limit: 3)
     paginate_prev_fn.()
 
     assert_receive({:paginated, :prev})
   end
 
   test "paginate_collection next" do
-    {:ok, %Collection{next: paginate_next_fn}} = Effects.all(limit: 3)
+    {:ok, %Collection{next: paginate_next_fn}} = Effects.all(Server.testnet(), limit: 3)
     paginate_next_fn.()
 
     assert_receive({:paginated, :next})
@@ -152,6 +152,6 @@ defmodule Stellar.Horizon.EffectsTest do
        status_code: 400,
        title: "Bad Request",
        type: "https://stellar.org/horizon-errors/bad_request"
-     }} = Effects.all(cursor: "error")
+     }} = Effects.all(Server.testnet(), cursor: "error")
   end
 end

--- a/test/horizon/fee_stats_test.exs
+++ b/test/horizon/fee_stats_test.exs
@@ -21,7 +21,7 @@ defmodule Stellar.Horizon.FeeStatsTest do
   use ExUnit.Case
 
   alias Stellar.Horizon.Client.CannedFeeStatRequests
-  alias Stellar.Horizon.{FeeStat, FeeStats}
+  alias Stellar.Horizon.{FeeStat, FeeStats, Server}
 
   setup do
     Application.put_env(:stellar_sdk, :http_client, CannedFeeStatRequests)
@@ -69,6 +69,6 @@ defmodule Stellar.Horizon.FeeStatsTest do
          p95: "100",
          p99: "100"
        }
-     }} = FeeStats.retrieve()
+     }} = FeeStats.retrieve(Server.testnet())
   end
 end

--- a/test/horizon/ledgers_test.exs
+++ b/test/horizon/ledgers_test.exs
@@ -88,6 +88,7 @@ defmodule Stellar.Horizon.LedgersTest do
     Ledger,
     Ledgers,
     Operation,
+    Server,
     Transaction
   }
 
@@ -123,7 +124,7 @@ defmodule Stellar.Horizon.LedgersTest do
        successful_transaction_count: 0,
        total_coins: "100000000000.0000000",
        tx_set_operation_count: 0
-     }} = Ledgers.retrieve(ledger_sequence)
+     }} = Ledgers.retrieve(Server.testnet(), ledger_sequence)
   end
 
   test "all/1" do
@@ -146,7 +147,7 @@ defmodule Stellar.Horizon.LedgersTest do
            protocol_version: 18
          }
        ]
-     }} = Ledgers.all()
+     }} = Ledgers.all(Server.testnet())
   end
 
   test "list_transactions/1", %{ledger_sequence: ledger_sequence} do
@@ -166,7 +167,7 @@ defmodule Stellar.Horizon.LedgersTest do
            ledger: 7855
          }
        ]
-     }} = Ledgers.list_transactions(ledger_sequence, limit: 3, order: :asc)
+     }} = Ledgers.list_transactions(Server.testnet(), ledger_sequence, limit: 3, order: :asc)
   end
 
   test "list_operations/1", %{ledger_sequence: ledger_sequence} do
@@ -189,7 +190,7 @@ defmodule Stellar.Horizon.LedgersTest do
            type_i: 0
          }
        ]
-     }} = Ledgers.list_operations(ledger_sequence, limit: 3, order: :desc)
+     }} = Ledgers.list_operations(Server.testnet(), ledger_sequence, limit: 3, order: :desc)
   end
 
   test "list_payments/1", %{ledger_sequence: ledger_sequence} do
@@ -211,7 +212,7 @@ defmodule Stellar.Horizon.LedgersTest do
            type_i: 1
          }
        ]
-     }} = Ledgers.list_payments(ledger_sequence, limit: 3)
+     }} = Ledgers.list_payments(Server.testnet(), ledger_sequence, limit: 3)
   end
 
   test "list_effects/1", %{ledger_sequence: ledger_sequence} do
@@ -224,18 +225,18 @@ defmodule Stellar.Horizon.LedgersTest do
          %Effect{type: "contract_debited", created_at: ~U[2023-10-10 15:53:13Z]},
          %Effect{type: "contract_credited", created_at: ~U[2023-10-10 15:52:40Z]}
        ]
-     }} = Ledgers.list_effects(ledger_sequence, limit: 5)
+     }} = Ledgers.list_effects(Server.testnet(), ledger_sequence, limit: 5)
   end
 
   test "paginate_collection prev" do
-    {:ok, %Collection{prev: paginate_prev_fn}} = Ledgers.all(limit: 3)
+    {:ok, %Collection{prev: paginate_prev_fn}} = Ledgers.all(Server.testnet(), limit: 3)
     paginate_prev_fn.()
 
     assert_receive({:paginated, :prev})
   end
 
   test "paginate_collection next" do
-    {:ok, %Collection{next: paginate_next_fn}} = Ledgers.all(limit: 3)
+    {:ok, %Collection{next: paginate_next_fn}} = Ledgers.all(Server.testnet(), limit: 3)
     paginate_next_fn.()
 
     assert_receive({:paginated, :next})
@@ -248,6 +249,6 @@ defmodule Stellar.Horizon.LedgersTest do
        status_code: 404,
        title: "Resource Missing",
        type: "https://stellar.org/horizon-errors/not_found"
-     }} = Ledgers.retrieve("not_found")
+     }} = Ledgers.retrieve(Server.testnet(), "not_found")
   end
 end

--- a/test/horizon/liquidity_pools_test.exs
+++ b/test/horizon/liquidity_pools_test.exs
@@ -242,7 +242,8 @@ defmodule Stellar.Horizon.LiquidityPoolsTest do
            ledger: 7855
          }
        ]
-     }} = LiquidityPools.list_transactions(Server.testnet(), liquidity_pool_id, limit: 3, order: :asc)
+     }} =
+      LiquidityPools.list_transactions(Server.testnet(), liquidity_pool_id, limit: 3, order: :asc)
   end
 
   test "list_operations/1", %{liquidity_pool_id: liquidity_pool_id} do
@@ -265,7 +266,8 @@ defmodule Stellar.Horizon.LiquidityPoolsTest do
            type_i: 0
          }
        ]
-     }} = LiquidityPools.list_operations(Server.testnet(), liquidity_pool_id, limit: 3, order: :desc)
+     }} =
+      LiquidityPools.list_operations(Server.testnet(), liquidity_pool_id, limit: 3, order: :desc)
   end
 
   test "list_effects/1", %{liquidity_pool_id: liquidity_pool_id} do

--- a/test/horizon/liquidity_pools_test.exs
+++ b/test/horizon/liquidity_pools_test.exs
@@ -131,6 +131,7 @@ defmodule Stellar.Horizon.LiquidityPoolsTest do
     LiquidityPool,
     LiquidityPools,
     Operation,
+    Server,
     Trade,
     Transaction
   }
@@ -168,7 +169,7 @@ defmodule Stellar.Horizon.LiquidityPoolsTest do
        total_shares: "500000000.0000000",
        total_trustlines: 1,
        type: "constant_product"
-     }} = LiquidityPools.retrieve(liquidity_pool_id)
+     }} = LiquidityPools.retrieve(Server.testnet(), liquidity_pool_id)
   end
 
   test "all/1" do
@@ -221,7 +222,7 @@ defmodule Stellar.Horizon.LiquidityPoolsTest do
            type: "constant_product"
          }
        ]
-     }} = LiquidityPools.all()
+     }} = LiquidityPools.all(Server.testnet())
   end
 
   test "list_transactions/1", %{liquidity_pool_id: liquidity_pool_id} do
@@ -241,7 +242,7 @@ defmodule Stellar.Horizon.LiquidityPoolsTest do
            ledger: 7855
          }
        ]
-     }} = LiquidityPools.list_transactions(liquidity_pool_id, limit: 3, order: :asc)
+     }} = LiquidityPools.list_transactions(Server.testnet(), liquidity_pool_id, limit: 3, order: :asc)
   end
 
   test "list_operations/1", %{liquidity_pool_id: liquidity_pool_id} do
@@ -264,7 +265,7 @@ defmodule Stellar.Horizon.LiquidityPoolsTest do
            type_i: 0
          }
        ]
-     }} = LiquidityPools.list_operations(liquidity_pool_id, limit: 3, order: :desc)
+     }} = LiquidityPools.list_operations(Server.testnet(), liquidity_pool_id, limit: 3, order: :desc)
   end
 
   test "list_effects/1", %{liquidity_pool_id: liquidity_pool_id} do
@@ -277,7 +278,7 @@ defmodule Stellar.Horizon.LiquidityPoolsTest do
          %Effect{type: "contract_debited", created_at: ~U[2023-10-10 15:53:13Z]},
          %Effect{type: "contract_credited", created_at: ~U[2023-10-10 15:52:40Z]}
        ]
-     }} = LiquidityPools.list_effects(liquidity_pool_id, limit: 5)
+     }} = LiquidityPools.list_effects(Server.testnet(), liquidity_pool_id, limit: 5)
   end
 
   test "list_trades/2", %{liquidity_pool_id: liquidity_pool_id} do
@@ -288,18 +289,18 @@ defmodule Stellar.Horizon.LiquidityPoolsTest do
          %Trade{base_amount: "10.0000000"},
          %Trade{base_amount: "748.5338945"}
        ]
-     }} = LiquidityPools.list_trades(liquidity_pool_id)
+     }} = LiquidityPools.list_trades(Server.testnet(), liquidity_pool_id)
   end
 
   test "paginate_collection prev" do
-    {:ok, %Collection{prev: paginate_prev_fn}} = LiquidityPools.all(limit: 3)
+    {:ok, %Collection{prev: paginate_prev_fn}} = LiquidityPools.all(Server.testnet(), limit: 3)
     paginate_prev_fn.()
 
     assert_receive({:paginated, :prev})
   end
 
   test "paginate_collection next" do
-    {:ok, %Collection{next: paginate_next_fn}} = LiquidityPools.all(limit: 3)
+    {:ok, %Collection{next: paginate_next_fn}} = LiquidityPools.all(Server.testnet(), limit: 3)
     paginate_next_fn.()
 
     assert_receive({:paginated, :next})
@@ -312,6 +313,6 @@ defmodule Stellar.Horizon.LiquidityPoolsTest do
        status_code: 404,
        title: "Resource Missing",
        type: "https://stellar.org/horizon-errors/not_found"
-     }} = LiquidityPools.retrieve("not_found")
+     }} = LiquidityPools.retrieve(Server.testnet(), "not_found")
   end
 end

--- a/test/horizon/offers_test.exs
+++ b/test/horizon/offers_test.exs
@@ -53,7 +53,7 @@ defmodule Stellar.Horizon.OffersTest do
   use ExUnit.Case
 
   alias Stellar.Horizon.Client.CannedOfferRequests
-  alias Stellar.Horizon.{Collection, Error, Offer, Offers, Trade}
+  alias Stellar.Horizon.{Collection, Error, Offer, Offers, Trade, Server}
 
   setup do
     Application.put_env(:stellar_sdk, :http_client, CannedOfferRequests)
@@ -83,7 +83,7 @@ defmodule Stellar.Horizon.OffersTest do
          asset_type: "credit_alphanum4"
        },
        sponsor: nil
-     }} = Offers.retrieve(offer_id)
+     }} = Offers.retrieve(Server.testnet(), offer_id)
   end
 
   test "all/1" do
@@ -109,7 +109,7 @@ defmodule Stellar.Horizon.OffersTest do
            price: "12.8899964"
          }
        ]
-     }} = Offers.all()
+     }} = Offers.all(Server.testnet())
   end
 
   test "list_trades/2", %{offer_id: offer_id} do
@@ -120,18 +120,18 @@ defmodule Stellar.Horizon.OffersTest do
          %Trade{base_offer_id: ^offer_id, base_amount: "10.0000000"},
          %Trade{base_offer_id: ^offer_id, base_amount: "748.5338945"}
        ]
-     }} = Offers.list_trades(offer_id)
+     }} = Offers.list_trades(Server.testnet(), offer_id)
   end
 
   test "paginate_collection prev" do
-    {:ok, %Collection{prev: paginate_prev_fn}} = Offers.all(limit: 3)
+    {:ok, %Collection{prev: paginate_prev_fn}} = Offers.all(Server.testnet(), limit: 3)
     paginate_prev_fn.()
 
     assert_receive({:paginated, :prev})
   end
 
   test "paginate_collection next" do
-    {:ok, %Collection{next: paginate_next_fn}} = Offers.all(limit: 3)
+    {:ok, %Collection{next: paginate_next_fn}} = Offers.all(Server.testnet(), limit: 3)
     paginate_next_fn.()
 
     assert_receive({:paginated, :next})
@@ -144,6 +144,6 @@ defmodule Stellar.Horizon.OffersTest do
        status_code: 404,
        title: "Resource Missing",
        type: "https://stellar.org/horizon-errors/not_found"
-     }} = Offers.retrieve("not_found")
+     }} = Offers.retrieve(Server.testnet(), "not_found")
   end
 end

--- a/test/horizon/operations_test.exs
+++ b/test/horizon/operations_test.exs
@@ -82,7 +82,8 @@ defmodule Stellar.Horizon.OperationsTest do
     Effect,
     Error,
     Operation,
-    Operations
+    Operations,
+    Server
   }
 
   alias Stellar.Horizon.Operation.{CreateAccount, Payment, SetOptions, PathPaymentStrictSend}
@@ -120,7 +121,7 @@ defmodule Stellar.Horizon.OperationsTest do
        transaction_successful: true,
        type: "path_payment_strict_send",
        type_i: 13
-     }} = Operations.retrieve(operation_id)
+     }} = Operations.retrieve(Server.testnet(), operation_id)
   end
 
   test "all/1" do
@@ -177,7 +178,7 @@ defmodule Stellar.Horizon.OperationsTest do
            type_i: 0
          }
        ]
-     }} = Operations.all()
+     }} = Operations.all(Server.testnet())
   end
 
   test "list_effects/2", %{operation_id: operation_id} do
@@ -190,7 +191,7 @@ defmodule Stellar.Horizon.OperationsTest do
          %Effect{type: "contract_debited", created_at: ~U[2023-10-10 15:53:13Z]},
          %Effect{type: "contract_credited", created_at: ~U[2023-10-10 15:52:40Z]}
        ]
-     }} = Operations.list_effects(operation_id, limit: 5)
+     }} = Operations.list_effects(Server.testnet(), operation_id, limit: 5)
   end
 
   test "list_payments/1" do
@@ -215,18 +216,18 @@ defmodule Stellar.Horizon.OperationsTest do
            type_i: 1
          }
        ]
-     }} = Operations.list_payments(limit: 3)
+     }} = Operations.list_payments(Server.testnet(), limit: 3)
   end
 
   test "paginate_collection prev" do
-    {:ok, %Collection{prev: paginate_prev_fn}} = Operations.all(limit: 3)
+    {:ok, %Collection{prev: paginate_prev_fn}} = Operations.all(Server.testnet(), limit: 3)
     paginate_prev_fn.()
 
     assert_receive({:paginated, :prev})
   end
 
   test "paginate_collection next" do
-    {:ok, %Collection{next: paginate_next_fn}} = Operations.all(limit: 3)
+    {:ok, %Collection{next: paginate_next_fn}} = Operations.all(Server.testnet(), limit: 3)
     paginate_next_fn.()
 
     assert_receive({:paginated, :next})
@@ -239,6 +240,6 @@ defmodule Stellar.Horizon.OperationsTest do
        status_code: 404,
        title: "Resource Missing",
        type: "https://stellar.org/horizon-errors/not_found"
-     }} = Operations.retrieve("error")
+     }} = Operations.retrieve(Server.testnet(), "error")
   end
 end

--- a/test/horizon/order_books_test.exs
+++ b/test/horizon/order_books_test.exs
@@ -33,7 +33,7 @@ defmodule Stellar.Horizon.OrderBooksTest do
   use ExUnit.Case
 
   alias Stellar.Horizon.Client.CannedOrderBooksRequests
-  alias Stellar.Horizon.{OrderBooks, OrderBook, Error}
+  alias Stellar.Horizon.{OrderBooks, OrderBook, Error, Server}
   alias Stellar.Horizon.OrderBook.Price
 
   setup do
@@ -92,6 +92,7 @@ defmodule Stellar.Horizon.OrderBooksTest do
        }
      }} =
       OrderBooks.retrieve(
+        Server.testnet(),
         selling_asset: selling_asset,
         buying_asset: buying_asset,
         limit: limit
@@ -104,6 +105,6 @@ defmodule Stellar.Horizon.OrderBooksTest do
        status_code: 400,
        title: "Invalid Order Book Parameters",
        type: "https://stellar.org/horizon-errors/invalid_order_book"
-     }} = OrderBooks.retrieve(buying_asset: :error)
+     }} = OrderBooks.retrieve(Server.testnet(), buying_asset: :error)
   end
 end

--- a/test/horizon/payment_paths_test.exs
+++ b/test/horizon/payment_paths_test.exs
@@ -68,7 +68,7 @@ defmodule Stellar.Horizon.PaymentPathsTest do
   use ExUnit.Case
 
   alias Stellar.Horizon.Client.CannedPathRequests
-  alias Stellar.Horizon.{Path, Paths, PaymentPaths, Error}
+  alias Stellar.Horizon.{Path, Paths, PaymentPaths, Error, Server}
 
   setup do
     Application.put_env(:stellar_sdk, :http_client, CannedPathRequests)
@@ -111,6 +111,7 @@ defmodule Stellar.Horizon.PaymentPathsTest do
        ]
      }} =
       PaymentPaths.list_paths(
+        Server.testnet(),
         source_account: source_account,
         destination_asset: destination_asset,
         destination_amount: destination_amount
@@ -138,6 +139,7 @@ defmodule Stellar.Horizon.PaymentPathsTest do
        ]
      }} =
       PaymentPaths.list_receive_paths(
+        Server.testnet(),
         destination_asset: destination_asset,
         destination_amount: destination_amount,
         source_account: source_account
@@ -177,6 +179,7 @@ defmodule Stellar.Horizon.PaymentPathsTest do
        ]
      }} =
       PaymentPaths.list_send_paths(
+        Server.testnet(),
         source_asset: source_asset,
         source_amount: source_amount,
         destination_assets: destination_assets
@@ -190,7 +193,7 @@ defmodule Stellar.Horizon.PaymentPathsTest do
        extras: %{invalid_field: "destination_asset_type", reason: "Missing required field"},
        status_code: 400,
        title: "Bad Request"
-     }} = PaymentPaths.list_receive_paths(destination_amount: "error")
+     }} = PaymentPaths.list_receive_paths(Server.testnet(), destination_amount: "error")
   end
 
   test "list strict send error" do
@@ -200,6 +203,6 @@ defmodule Stellar.Horizon.PaymentPathsTest do
        extras: %{invalid_field: "source_asset_type", reason: "Missing required field"},
        status_code: 400,
        title: "Bad Request"
-     }} = PaymentPaths.list_send_paths(source_amount: "error")
+     }} = PaymentPaths.list_send_paths(Server.testnet(), source_amount: "error")
   end
 end

--- a/test/horizon/request_test.exs
+++ b/test/horizon/request_test.exs
@@ -46,8 +46,15 @@ defmodule Stellar.Horizon.RequestTest do
   end
 
   test "new/1", %{server: server, endpoint: endpoint, hash: hash} do
-    %Request{server: ^server, method: :get, endpoint: ^endpoint, path: ^hash, body: [], headers: [], query: []} =
-      Request.new(server, :get, endpoint, path: hash)
+    %Request{
+      server: ^server,
+      method: :get,
+      endpoint: ^endpoint,
+      path: ^hash,
+      body: [],
+      headers: [],
+      query: []
+    } = Request.new(server, :get, endpoint, path: hash)
   end
 
   test "new/1 with_segment", %{
@@ -67,7 +74,8 @@ defmodule Stellar.Horizon.RequestTest do
       body: [],
       headers: [],
       query: []
-    } = Request.new(server, :get, endpoint, path: hash, segment: segment, segment_path: segment_path)
+    } =
+      Request.new(server, :get, endpoint, path: hash, segment: segment, segment_path: segment_path)
   end
 
   test "add_body/2", %{server: server, endpoint: endpoint, body: body} do

--- a/test/horizon/server_test.exs
+++ b/test/horizon/server_test.exs
@@ -1,0 +1,25 @@
+defmodule Stellar.Horizon.ServerTest do
+  use ExUnit.Case
+
+  alias Stellar.Horizon.Server
+
+  test "new/1" do
+    %Server{url: "https://standalone-horizon.com"} = Server.new("https://standalone-horizon.com")
+  end
+
+  test "public/0" do
+    %Server{url: "https://horizon.stellar.org"} = Server.public()
+  end
+
+  test "testnet/0" do
+    %Server{url: "https://horizon-testnet.stellar.org"} = Server.testnet()
+  end
+
+  test "futurenet/0" do
+    %Server{url: "https://horizon-futurenet.stellar.org"} = Server.futurenet()
+  end
+
+  test "local/0" do
+    %Server{url: "http://localhost:8000"} = Server.local()
+  end
+end

--- a/test/horizon/server_test.exs
+++ b/test/horizon/server_test.exs
@@ -4,7 +4,7 @@ defmodule Stellar.Horizon.ServerTest do
   alias Stellar.Horizon.Server
 
   test "new/1" do
-    %Server{url: "https://standalone-horizon.com"} = Server.new("https://standalone-horizon.com")
+    %Server{url: "https://horizon-standalone.com"} = Server.new("https://horizon-standalone.com")
   end
 
   test "public/0" do

--- a/test/horizon/trade_aggregations_test.exs
+++ b/test/horizon/trade_aggregations_test.exs
@@ -68,7 +68,7 @@ defmodule Stellar.Horizon.TradeAggregationsTest do
   use ExUnit.Case
 
   alias Stellar.Horizon.Client.CannedTradeAggregationRequests
-  alias Stellar.Horizon.{Collection, TradeAggregation, TradeAggregations, Error}
+  alias Stellar.Horizon.{Collection, TradeAggregation, TradeAggregations, Error, Server}
 
   setup do
     Application.put_env(:stellar_sdk, :http_client, CannedTradeAggregationRequests)
@@ -134,6 +134,7 @@ defmodule Stellar.Horizon.TradeAggregationsTest do
        ]
      }} =
       TradeAggregations.list_trade_aggregations(
+        Server.testnet(),
         base_asset: base_asset,
         counter_asset: counter_asset,
         resolution: resolution,
@@ -153,6 +154,7 @@ defmodule Stellar.Horizon.TradeAggregationsTest do
   } do
     {:ok, %Collection{prev: paginate_prev_fn}} =
       TradeAggregations.list_trade_aggregations(
+        Server.testnet(),
         base_asset: base_asset,
         counter_asset: counter_asset,
         resolution: resolution,
@@ -176,6 +178,7 @@ defmodule Stellar.Horizon.TradeAggregationsTest do
   } do
     {:ok, %Collection{next: paginate_next_fn}} =
       TradeAggregations.list_trade_aggregations(
+        Server.testnet(),
         base_asset: base_asset,
         counter_asset: counter_asset,
         resolution: resolution,
@@ -197,6 +200,6 @@ defmodule Stellar.Horizon.TradeAggregationsTest do
        status_code: 400,
        title: "Bad Request",
        type: "https://stellar.org/horizon-errors/bad_request"
-     }} = TradeAggregations.list_trade_aggregations(base_asset: :error)
+     }} = TradeAggregations.list_trade_aggregations(Server.testnet(), base_asset: :error)
   end
 end

--- a/test/horizon/trades_test.exs
+++ b/test/horizon/trades_test.exs
@@ -55,7 +55,7 @@ defmodule Stellar.Horizon.TradesTest do
   use ExUnit.Case
 
   alias Stellar.Horizon.Client.CannedTradeRequests
-  alias Stellar.Horizon.{Collection, Error, Trade, Trades}
+  alias Stellar.Horizon.{Collection, Error, Trade, Trades, Server}
 
   setup do
     Application.put_env(:stellar_sdk, :http_client, CannedTradeRequests)
@@ -136,18 +136,18 @@ defmodule Stellar.Horizon.TradesTest do
            trade_type: nil
          }
        ]
-     }} = Trades.all(limit: 3)
+     }} = Trades.all(Server.testnet(), limit: 3)
   end
 
   test "paginate_collection prev" do
-    {:ok, %Collection{prev: paginate_prev_fn}} = Trades.all(limit: 3)
+    {:ok, %Collection{prev: paginate_prev_fn}} = Trades.all(Server.testnet(), limit: 3)
     paginate_prev_fn.()
 
     assert_receive({:paginated, :prev})
   end
 
   test "paginate_collection next" do
-    {:ok, %Collection{next: paginate_next_fn}} = Trades.all(limit: 3)
+    {:ok, %Collection{next: paginate_next_fn}} = Trades.all(Server.testnet(), limit: 3)
     paginate_next_fn.()
 
     assert_receive({:paginated, :next})
@@ -161,6 +161,6 @@ defmodule Stellar.Horizon.TradesTest do
        status_code: 400,
        title: "Bad Request",
        type: "https://stellar.org/horizon-errors/bad_request"
-     }} = Trades.all(cursor: "error")
+     }} = Trades.all(Server.testnet(), cursor: "error")
   end
 end

--- a/test/horizon/transactions_test.exs
+++ b/test/horizon/transactions_test.exs
@@ -107,7 +107,8 @@ defmodule Stellar.Horizon.TransactionsTest do
     Transactions,
     Transaction.Preconditions,
     Transaction.TimeBounds,
-    Transaction.LedgerBounds
+    Transaction.LedgerBounds,
+    Server
   }
 
   alias Stellar.Horizon.Operation.{CreateAccount, Payment, SetOptions}
@@ -129,7 +130,7 @@ defmodule Stellar.Horizon.TransactionsTest do
 
   test "create/1", %{base64_envelope: base64_envelope, hash: hash} do
     {:ok, %Transaction{successful: true, envelope_xdr: ^base64_envelope, hash: ^hash}} =
-      Transactions.create(base64_envelope)
+      Transactions.create(Server.testnet(), base64_envelope)
   end
 
   test "retrieve/1", %{
@@ -175,7 +176,7 @@ defmodule Stellar.Horizon.TransactionsTest do
            "GCO2IP3MJNUOKS4PUDI4C7LGGMQDJGXG3COYX3WSB4HHNAHKYV5YL3VC"
          ]
        }
-     }} = Transactions.retrieve(hash)
+     }} = Transactions.retrieve(Server.testnet(), hash)
   end
 
   test "all/1" do
@@ -192,7 +193,7 @@ defmodule Stellar.Horizon.TransactionsTest do
            hash: "3ce2aca2fed36da2faea31352c76c5e412348887a4c119b1e90de8d1b937396a"
          }
        ]
-     }} = Transactions.all(limit: 3)
+     }} = Transactions.all(Server.testnet(), limit: 3)
   end
 
   test "list_effects/2", %{hash: hash} do
@@ -205,7 +206,7 @@ defmodule Stellar.Horizon.TransactionsTest do
          %Effect{type: "contract_debited", created_at: ~U[2023-10-10 15:53:13Z]},
          %Effect{type: "contract_credited", created_at: ~U[2023-10-10 15:52:40Z]}
        ]
-     }} = Transactions.list_effects(hash, limit: 5)
+     }} = Transactions.list_effects(Server.testnet(), hash, limit: 5)
   end
 
   test "list_operations/2", %{hash: hash, source_account: source_account} do
@@ -231,18 +232,18 @@ defmodule Stellar.Horizon.TransactionsTest do
            type_i: 0
          }
        ]
-     }} = Transactions.list_operations(hash, limit: 3, order: :desc)
+     }} = Transactions.list_operations(Server.testnet(), hash, limit: 3, order: :desc)
   end
 
   test "paginate_collection prev" do
-    {:ok, %Collection{prev: paginate_prev_fn}} = Transactions.all(limit: 3)
+    {:ok, %Collection{prev: paginate_prev_fn}} = Transactions.all(Server.testnet(), limit: 3)
     paginate_prev_fn.()
 
     assert_receive({:paginated, :prev})
   end
 
   test "paginate_collection next" do
-    {:ok, %Collection{next: paginate_next_fn}} = Transactions.all(limit: 3)
+    {:ok, %Collection{next: paginate_next_fn}} = Transactions.all(Server.testnet(), limit: 3)
     paginate_next_fn.()
 
     assert_receive({:paginated, :next})
@@ -254,6 +255,6 @@ defmodule Stellar.Horizon.TransactionsTest do
        status_code: 400,
        title: "Transaction Failed",
        extras: %{result_codes: %{transaction: "tx_insufficient_fee"}}
-     }} = Transactions.create("bad")
+     }} = Transactions.create(Server.testnet(), "bad")
   end
 end

--- a/test/util/network_test.exs
+++ b/test/util/network_test.exs
@@ -3,40 +3,49 @@ defmodule Stellar.NetworkTest do
 
   alias Stellar.Network
 
-  @test_network_url "https://horizon-testnet.stellar.org"
-  @test_passphrase "Test SDF Network ; September 2015"
-
-  @public_network_url "https://horizon.stellar.org"
   @public_passphrase "Public Global Stellar Network ; September 2015"
+  @testnet_passphrase "Test SDF Network ; September 2015"
+  @futurenet_passphrase "Test SDF Future Network ; October 2022"
+  @standalone_passphrase "Standalone Network ; February 2017"
 
-  test "base_url/0" do
-    @test_network_url = Network.base_url()
-  end
+  @public_horizon_url "https://horizon.stellar.org"
+  @testnet_horizon_url "https://horizon-testnet.stellar.org"
+  @futurenet_horizon_url "https://horizon-futurenet.stellar.org"
+  @local_horizon_url "http://localhost:8000"
 
-  test "passphrase/0" do
-    @test_passphrase = Network.passphrase()
-  end
-
-  test "current/0" do
-    :test = Network.current()
-  end
-
-  describe "config/0" do
-    setup do
-      on_exit(fn -> Application.put_env(:stellar_sdk, :network, :test) end)
-      Application.put_env(:stellar_sdk, :network, :public)
+  describe "network passphrases" do
+    test "public_passphrase/0" do
+      @public_passphrase = Network.public_passphrase()
     end
 
-    test "base_url/0" do
-      @public_network_url = Network.base_url()
+    test "testnet_passphrase/0" do
+      @testnet_passphrase = Network.testnet_passphrase()
     end
 
-    test "passphrase/0" do
-      @public_passphrase = Network.passphrase()
+    test "futurenet_passphrase/0" do
+      @futurenet_passphrase = Network.futurenet_passphrase()
     end
 
-    test "current/0" do
-      :public = Network.current()
+    test "standalone_passphrase/0" do
+      @standalone_passphrase = Network.standalone_passphrase()
+    end
+  end
+
+  describe "network horizon urls" do
+    test "public_horizon_url/0" do
+      @public_horizon_url = Network.public_horizon_url()
+    end
+
+    test "testnet_horizon_url/0" do
+      @testnet_horizon_url = Network.testnet_horizon_url()
+    end
+
+    test "futurenet_horizon_url/0" do
+      @futurenet_horizon_url = Network.futurenet_horizon_url()
+    end
+
+    test "local_horizon_url/0" do
+      @local_horizon_url = Network.local_horizon_url()
     end
   end
 end


### PR DESCRIPTION
This PR adds the `Stellar.Horizon.Server` struct which is used in all the functions that make an HTTP request to some Horizon endpoint.

Contributes to #352 

Horizon
- [x] Create a `Stellar.Horizon.Server` struct.
- [x] Receive a `Stellar.Horizon.Server` struct in every module inside the Horizon boundary.
