### PR TITLE
[TxBuild] Dynamic network configuration: Receive `network_passphrase` in TxBuild and SorobanAuhorizationEntry

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The **Stellar SDK** enables the construction, signing and encoding of Stellar [t
 
 This library is aimed at developers building Elixir applications that interact with the [**Stellar network**][stellar].
 
-> **Note**
+> [!NOTE]
 > If you are a smart contract developer building on Soroban, we recommend using [Soroban.ex][soroban.ex], a library built on top of Stellar SDK which offers a developer-friendly interface for interacting with Soroban smart contracts and Soroban-RPC server.
 
 #### Protocol Version Support
@@ -105,15 +105,15 @@ Stellar relies on public key cryptography to ensure that transactions are secure
 [Transactions][stellar-docs-tx] are commands that modify the ledger state. They consist of a list of operations (up to 100) used to send payments, enter orders into the decentralized exchange, change settings on accounts, and authorize accounts to hold assets.
 
 ```elixir
-# set the source account (this accound should exist in the ledger)
+# set the source account (this account should exist in the ledger)
 source_account = Stellar.TxBuild.Account.new("GDC3W2X5KUTZRTQIKXM5D2I5WG5JYSEJQWEELVPQ5YMWZR6CA2JJ35RW")
 
 # initialize a transaction
-Stellar.TxBuild.new(source_account)
+Stellar.TxBuild.new(source_account) # network_passphrase defaults to Stellar.Network.testnet_passphrase()
 
 # initialize a transaction with options
-# allowed options: memo, sequence_number, base_fee, preconditions
-Stellar.TxBuild.new(source_account, memo: memo, sequence_number: sequence_number)
+# allowed options: network_passphrase, memo, sequence_number, base_fee, preconditions
+Stellar.TxBuild.new(source_account, network_passphrase: Stellar.Network.public_passphrase(), memo: memo, sequence_number: sequence_number)
 ```
 
 #### Memos
@@ -125,7 +125,7 @@ A [memo][stellar-docs-memo] contains optional extra information for the transact
 * **`MEMO_RETURN`** : A 32 byte hash intended to be interpreted as the hash of the transaction the sender is refunding.
 
 ```elixir
-# set the source account (this accound should exist in the ledger)
+# set the source account (this account should exist in the ledger)
 source_account = Stellar.TxBuild.Account.new("GDC3W2X5KUTZRTQIKXM5D2I5WG5JYSEJQWEELVPQ5YMWZR6CA2JJ35RW")
 
 # build a memo
@@ -146,7 +146,7 @@ memo = Stellar.TxBuild.Memo.new(return: "d83f67dc041e66085100859239b58d3f3292455
 Each transaction has a [sequence number][stellar-docs-sequence-number] associated with the source account. Transactions follow a strict ordering rule when it comes to processing transactions per account in order to prevent double-spending.
 
 ```elixir
-# set the source account (this accound should exist in the ledger)
+# set the source account (this account should exist in the ledger)
 source_account = Stellar.TxBuild.Account.new("GDC3W2X5KUTZRTQIKXM5D2I5WG5JYSEJQWEELVPQ5YMWZR6CA2JJ35RW")
 
 # fetch next account's sequence number from Horizon
@@ -170,7 +170,7 @@ sequence_number = Stellar.TxBuild.SequenceNumber.new(seq_num)
 Each transaction incurs a [fee][stellar-docs-fee], which is paid by the source account. When you submit a transaction, you set the maximum that you are willing to pay per operation, but you’re charged the minimum fee possible based on network activity.
 
 ```elixir
-# set the source account (this accound should exist in the ledger)
+# set the source account (this account should exist in the ledger)
 source_account = Stellar.TxBuild.Account.new("GDC3W2X5KUTZRTQIKXM5D2I5WG5JYSEJQWEELVPQ5YMWZR6CA2JJ35RW")
 
 # build a fee
@@ -199,7 +199,7 @@ Proposed on the [Stellar protocol-19][stellar-protocol-19] implementation, [Prec
 - **Extra Signers**: A transaction can specify up to two [Extra signers][stellar-docs-extra-signers] (of any type) even if those signatures would not otherwise be required to authorize the transaction.
 
 ```elixir
-# set the source account (this accound should exist in the ledger)
+# set the source account (this account should exist in the ledger)
 source_account = Stellar.TxBuild.Account.new("GDC3W2X5KUTZRTQIKXM5D2I5WG5JYSEJQWEELVPQ5YMWZR6CA2JJ35RW")
 
 # TimeBounds ---------------------------------------------------------------------------
@@ -265,7 +265,7 @@ preconditions =
 [Operations][stellar-docs-list-operations] represent a desired change to the ledger: payments, offers to exchange currency, changes made to account options, etc. Operations are submitted to the Stellar network grouped in a Transaction. Single transactions may have up to 100 operations.
 
 ```elixir
-# set the source account (this accound should exist in the ledger)
+# set the source account (this account should exist in the ledger)
 source_account = Stellar.TxBuild.Account.new("GDC3W2X5KUTZRTQIKXM5D2I5WG5JYSEJQWEELVPQ5YMWZR6CA2JJ35RW")
 
 # build a create_account operation
@@ -330,7 +330,7 @@ signature =
 In some cases, a transaction may need more than one signature. If the transaction has operations with multiple source accounts, it requires the source account signature for each operation. Additional signatures are required if the account associated with the transaction has multiple public keys.
 
 ```elixir
-# set the source account (this accound should exist in the ledger)
+# set the source account (this account should exist in the ledger)
 source_account = Stellar.TxBuild.Account.new("GDC3W2X5KUTZRTQIKXM5D2I5WG5JYSEJQWEELVPQ5YMWZR6CA2JJ35RW")
 
 # build an operation
@@ -366,7 +366,7 @@ signature2 = Stellar.TxBuild.Signature.new(ed25519: "SA2NWVOPQMQYAU5RATOE7HJLMPL
 Once a transaction has been filled out, it is wrapped in a [Transaction envelope][stellar-docs-tx-envelope] containing the transaction as well as a set of signatures.
 
 ```elixir
-# set the source account (this accound should exist in the ledger)
+# set the source account (this account should exist in the ledger)
 source_account = Stellar.TxBuild.Account.new("GDC3W2X5KUTZRTQIKXM5D2I5WG5JYSEJQWEELVPQ5YMWZR6CA2JJ35RW")
 
 # build an operation
@@ -395,7 +395,7 @@ source_account
 The transaction can now be submitted to the Stellar network.
 
 ```elixir
-# set the source account (this accound should exist in the ledger)
+# set the source account (this account should exist in the ledger)
 source_account = Stellar.TxBuild.Account.new("GDC3W2X5KUTZRTQIKXM5D2I5WG5JYSEJQWEELVPQ5YMWZR6CA2JJ35RW")
 
 # fetch next account's sequence number from Horizon

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,0 @@
-use Mix.Config
-
-import_config "#{Mix.env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,3 +1,0 @@
-use Mix.Config
-
-config :stellar_sdk, network: :test

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,3 +1,0 @@
-use Mix.Config
-
-config :stellar_sdk, network: :public

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,3 +1,0 @@
-use Mix.Config
-
-config :stellar_sdk, network: :test

--- a/lib/tx_build.ex
+++ b/lib/tx_build.ex
@@ -63,8 +63,8 @@ defmodule Stellar.TxBuild do
   def envelope(tx), do: impl().envelope(tx)
 
   @impl true
-  def sign_envelope(base64_envelope, signatures),
-    do: impl().sign_envelope(base64_envelope, signatures)
+  def sign_envelope(base64_envelope, signatures, network_passphrase),
+    do: impl().sign_envelope(base64_envelope, signatures, network_passphrase)
 
   @impl true
   def hash(tx), do: impl().hash(tx)

--- a/lib/tx_build.ex
+++ b/lib/tx_build.ex
@@ -10,17 +10,23 @@ defmodule Stellar.TxBuild do
   @type tx :: Transaction.t()
   @type signatures :: Signature.t() | list(Signature.t())
   @type tx_envelope :: TransactionEnvelope.t() | nil
+  @type network_passphrase :: String.t()
 
   @type t :: %__MODULE__{
           tx: tx(),
           signatures: signatures(),
-          tx_envelope: tx_envelope()
+          tx_envelope: tx_envelope(),
+          network_passphrase: network_passphrase()
         }
 
-  defstruct [:tx, :signatures, :tx_envelope]
+  defstruct [:tx, :signatures, :tx_envelope, :network_passphrase]
 
   @impl true
   def new(account, opts \\ []), do: impl().new(account, opts)
+
+  @impl true
+  def set_network_passphrase(tx, network_passphrase),
+    do: impl().set_network_passphrase(tx, network_passphrase)
 
   @impl true
   def add_memo(tx, memo), do: impl().add_memo(tx, memo)

--- a/lib/tx_build/default.ex
+++ b/lib/tx_build/default.ex
@@ -69,9 +69,8 @@ defmodule Stellar.TxBuild.Default do
   def new(_source_account, _opts), do: {:error, :invalid_source_account}
 
   @impl true
-  def set_network_passphrase({:ok, %TxBuild{} = tx_build}, network_passphrase) do
-    {:ok, %{tx_build | network_passphrase: network_passphrase}}
-  end
+  def set_network_passphrase({:ok, %TxBuild{} = tx_build}, network_passphrase),
+    do: {:ok, %{tx_build | network_passphrase: network_passphrase}}
 
   @impl true
   def add_memo({:ok, %TxBuild{tx: tx} = tx_build}, %Memo{} = memo) do

--- a/lib/tx_build/default.ex
+++ b/lib/tx_build/default.ex
@@ -3,7 +3,7 @@ defmodule Stellar.TxBuild.Default do
   Default TxBuild implementation.
   """
   alias StellarBase.XDR.{TransactionExt, SorobanTransactionData}
-  alias Stellar.TxBuild
+  alias Stellar.{TxBuild, Network}
 
   alias Stellar.TxBuild.{
     Account,
@@ -33,6 +33,7 @@ defmodule Stellar.TxBuild.Default do
 
   @impl true
   def new(%Account{} = source_account, opts) do
+    network_passphrase = Keyword.get(opts, :network_passphrase, Network.testnet_passphrase())
     sequence_number = Keyword.get(opts, :sequence_number, SequenceNumber.new())
     base_fee = Keyword.get(opts, :base_fee, BaseFee.new())
     memo = Keyword.get(opts, :memo, Memo.new())
@@ -52,7 +53,13 @@ defmodule Stellar.TxBuild.Default do
            operations: operations
          ) do
       %Transaction{} = transaction ->
-        {:ok, %TxBuild{tx: transaction, signatures: [], tx_envelope: nil}}
+        {:ok,
+         %TxBuild{
+           tx: transaction,
+           signatures: [],
+           tx_envelope: nil,
+           network_passphrase: network_passphrase
+         }}
 
       error ->
         error
@@ -60,6 +67,11 @@ defmodule Stellar.TxBuild.Default do
   end
 
   def new(_source_account, _opts), do: {:error, :invalid_source_account}
+
+  @impl true
+  def set_network_passphrase({:ok, %TxBuild{} = tx_build}, network_passphrase) do
+    {:ok, %{tx_build | network_passphrase: network_passphrase}}
+  end
 
   @impl true
   def add_memo({:ok, %TxBuild{tx: tx} = tx_build}, %Memo{} = memo) do
@@ -205,16 +217,29 @@ defmodule Stellar.TxBuild.Default do
   def sign(error, _signature), do: error
 
   @impl true
-  def build({:ok, %TxBuild{tx: tx, signatures: signatures} = tx_build}) do
-    {:ok, %{tx_build | tx_envelope: TransactionEnvelope.new(tx, signatures)}}
+  def build(
+        {:ok,
+         %TxBuild{tx: tx, signatures: signatures, network_passphrase: network_passphrase} =
+           tx_build}
+      ) do
+    tx_envelope =
+      TransactionEnvelope.new(
+        tx: tx,
+        signatures: signatures,
+        network_passphrase: network_passphrase
+      )
+
+    {:ok, %{tx_build | tx_envelope: tx_envelope}}
   end
 
   def build(error), do: error
 
   @impl true
-  def envelope({:ok, %TxBuild{tx: tx, signatures: signatures}}) do
-    tx
-    |> TransactionEnvelope.new(signatures)
+  def envelope(
+        {:ok, %TxBuild{tx: tx, signatures: signatures, network_passphrase: network_passphrase}}
+      ) do
+    [tx: tx, signatures: signatures, network_passphrase: network_passphrase]
+    |> TransactionEnvelope.new()
     |> TransactionEnvelope.to_xdr()
     |> TransactionEnvelope.to_base64()
     |> (&{:ok, &1}).()
@@ -242,10 +267,10 @@ defmodule Stellar.TxBuild.Default do
   def sign_envelope(_tx_base64, _signature), do: {:error, :invalid_signature}
 
   @impl true
-  def hash({:ok, %TxBuild{tx: tx}}) do
+  def hash({:ok, %TxBuild{tx: tx, network_passphrase: network_passphrase}}) do
     tx
     |> Transaction.to_xdr()
-    |> TransactionSignature.base_signature()
+    |> TransactionSignature.base_signature(network_passphrase)
     |> Base.encode16(case: :lower)
     |> (&{:ok, &1}).()
   end

--- a/lib/tx_build/default.ex
+++ b/lib/tx_build/default.ex
@@ -249,7 +249,9 @@ defmodule Stellar.TxBuild.Default do
 
   @impl true
   def sign_envelope(tx_base64, [], _network_passphrase), do: tx_base64
-  def sign_envelope({:ok, tx_base64}, signatures, network_passphrase), do: sign_envelope(tx_base64, signatures, network_passphrase)
+
+  def sign_envelope({:ok, tx_base64}, signatures, network_passphrase),
+    do: sign_envelope(tx_base64, signatures, network_passphrase)
 
   def sign_envelope(tx_base64, [%Signature{} = signature | signatures], network_passphrase) do
     tx_base64

--- a/lib/tx_build/default.ex
+++ b/lib/tx_build/default.ex
@@ -248,23 +248,23 @@ defmodule Stellar.TxBuild.Default do
   def envelope(error), do: error
 
   @impl true
-  def sign_envelope(tx_base64, []), do: tx_base64
-  def sign_envelope({:ok, tx_base64}, signatures), do: sign_envelope(tx_base64, signatures)
+  def sign_envelope(tx_base64, [], _network_passphrase), do: tx_base64
+  def sign_envelope({:ok, tx_base64}, signatures, network_passphrase), do: sign_envelope(tx_base64, signatures, network_passphrase)
 
-  def sign_envelope(tx_base64, [%Signature{} = signature | signatures]) do
+  def sign_envelope(tx_base64, [%Signature{} = signature | signatures], network_passphrase) do
     tx_base64
-    |> sign_envelope(signature)
-    |> sign_envelope(signatures)
+    |> sign_envelope(signature, network_passphrase)
+    |> sign_envelope(signatures, network_passphrase)
   end
 
-  def sign_envelope(tx_base64, %Signature{} = signature) do
+  def sign_envelope(tx_base64, %Signature{} = signature, network_passphrase) do
     tx_base64
-    |> TransactionEnvelope.add_signature(signature)
+    |> TransactionEnvelope.add_signature(signature, network_passphrase)
     |> TransactionEnvelope.to_base64()
     |> (&{:ok, &1}).()
   end
 
-  def sign_envelope(_tx_base64, _signature), do: {:error, :invalid_signature}
+  def sign_envelope(_tx_base64, _signature, _network_passphrase), do: {:error, :invalid_signature}
 
   @impl true
   def hash({:ok, %TxBuild{tx: tx, network_passphrase: network_passphrase}}) do

--- a/lib/tx_build/soroban_authorization_entry.ex
+++ b/lib/tx_build/soroban_authorization_entry.ex
@@ -10,7 +10,7 @@ defmodule Stellar.TxBuild.SorobanAuthorizationEntry do
 
   alias StellarBase.XDR.SorobanAddressCredentials, as: SorobanAddressCredentialsXDR
   alias StellarBase.XDR.SorobanAuthorizedInvocation, as: SorobanAuthorizedInvocationXDR
-  alias StellarBase.XDR.{EnvelopeType, Hash, Int64, SorobanAuthorizationEntry, UInt32}
+  alias StellarBase.XDR.{EnvelopeType, Int64, SorobanAuthorizationEntry, UInt32}
   alias Stellar.{KeyPair, Network}
 
   alias Stellar.TxBuild.{
@@ -223,8 +223,7 @@ defmodule Stellar.TxBuild.SorobanAuthorizationEntry do
 
     signature =
       network_passphrase
-      |> Network.network_id()
-      |> Hash.new()
+      |> Network.network_id_xdr()
       |> HashIDPreimageSorobanAuthorizationXDR.new(
         nonce,
         signature_expiration_ledger,

--- a/lib/tx_build/soroban_authorization_entry.ex
+++ b/lib/tx_build/soroban_authorization_entry.ex
@@ -74,7 +74,11 @@ defmodule Stellar.TxBuild.SorobanAuthorizationEntry do
 
   def to_xdr(_struct), do: {:error, :invalid_struct}
 
-  @spec sign(credentials :: t(), secret_key :: secret_key()) :: t() | error()
+  @spec sign(
+          credentials :: t(),
+          secret_key :: secret_key(),
+          network_passphrase :: network_passphrase()
+        ) :: t() | error()
   def sign(
         %__MODULE__{
           credentials: %SorobanCredentials{
@@ -131,7 +135,7 @@ defmodule Stellar.TxBuild.SorobanAuthorizationEntry do
     %{credentials | credentials: soroban_address_credentials}
   end
 
-  def sign(_args, _secret_key), do: {:error, :invalid_sign_args}
+  def sign(_args, _secret_key, _network_passphrase), do: {:error, :invalid_sign_args}
 
   @spec sign_xdr(
           base_64 :: base_64(),
@@ -140,7 +144,8 @@ defmodule Stellar.TxBuild.SorobanAuthorizationEntry do
           network_passphrase :: network_passphrase()
         ) :: sign_authorization() | error()
   def sign_xdr(base_64, secret_key, latest_ledger, network_passphrase)
-      when is_binary(base_64) and is_binary(secret_key) and is_integer(latest_ledger) and is_binary(network_passphrase) do
+      when is_binary(base_64) and is_binary(secret_key) and is_integer(latest_ledger) and
+             is_binary(network_passphrase) do
     {%SorobanAuthorizationEntry{
        credentials:
          %{
@@ -182,7 +187,8 @@ defmodule Stellar.TxBuild.SorobanAuthorizationEntry do
     |> Base.encode64()
   end
 
-  def sign_xdr(_base_64, _secret_key, _latest_ledger), do: {:error, :invalid_sign_args}
+  def sign_xdr(_base_64, _secret_key, _latest_ledger, _network_passphrase),
+    do: {:error, :invalid_sign_args}
 
   @spec hash(data :: binary()) :: binary()
   defp hash(data), do: :crypto.hash(:sha256, data)
@@ -209,7 +215,7 @@ defmodule Stellar.TxBuild.SorobanAuthorizationEntry do
          signature_expiration_ledger,
          root_invocation,
          secret_key,
-          network_passphrase
+         network_passphrase
        ) do
     {public_key, _secret_key} = KeyPair.from_secret_seed(secret_key)
     raw_public_key = KeyPair.raw_public_key(public_key)

--- a/lib/tx_build/spec.ex
+++ b/lib/tx_build/spec.ex
@@ -79,7 +79,7 @@ defmodule Stellar.TxBuild.Spec do
   @callback sign(tx_build(), signatures()) :: tx_build()
   @callback build(tx_build()) :: tx_build()
   @callback envelope(tx_build()) :: tx_envelope()
-  @callback sign_envelope(envelope(), signatures()) :: tx_envelope()
+  @callback sign_envelope(envelope(), signatures(), network_passphrase()) :: tx_envelope()
   @callback hash(tx_build()) :: tx_hash()
 
   @optional_callbacks add_memo: 2,

--- a/lib/tx_build/spec.ex
+++ b/lib/tx_build/spec.ex
@@ -34,6 +34,7 @@ defmodule Stellar.TxBuild.Spec do
 
   @type opts :: Keyword.t()
   @type account :: Account.t()
+  @type network_passphrase :: String.t()
   @type sequence_number :: SequenceNumber.t()
   @type memo :: Memo.t()
   @type base_fee :: BaseFee.t()
@@ -66,6 +67,7 @@ defmodule Stellar.TxBuild.Spec do
   @type tx_hash :: {:ok, hash()} | {:error, atom()}
 
   @callback new(account(), opts()) :: tx_build()
+  @callback set_network_passphrase(tx_build(), network_passphrase()) :: tx_build()
   @callback add_memo(tx_build(), memo()) :: tx_build()
   @callback set_time_bounds(tx_build(), time_bounds()) :: tx_build()
   @callback set_preconditions(tx_build(), preconditions()) :: tx_build()

--- a/lib/tx_build/transaction_signature.ex
+++ b/lib/tx_build/transaction_signature.ex
@@ -2,12 +2,12 @@ defmodule Stellar.TxBuild.TransactionSignature do
   @moduledoc """
   A module for tagging and signing transactions.
   """
+  alias Stellar.Network
   alias Stellar.TxBuild.{Transaction, Signature}
 
   alias StellarBase.XDR.{
     DecoratedSignatures,
     EnvelopeType,
-    Hash,
     TransactionEnvelope,
     TransactionSignaturePayload
   }
@@ -70,17 +70,10 @@ defmodule Stellar.TxBuild.TransactionSignature do
           binary()
   defp signature_payload(tagged_tx, network_passphrase) do
     network_passphrase
-    |> network_id_xdr()
+    |> Network.network_id_xdr()
     |> TransactionSignaturePayload.new(tagged_tx)
     |> TransactionSignaturePayload.encode_xdr!()
     |> hash()
-  end
-
-  @spec network_id_xdr(network_passphrase :: network_passphrase()) :: Hash.t()
-  defp network_id_xdr(network_passphrase) do
-    network_passphrase
-    |> hash()
-    |> Hash.new()
   end
 
   @spec hash(data :: binary()) :: binary()

--- a/lib/tx_build/transaction_signature.ex
+++ b/lib/tx_build/transaction_signature.ex
@@ -2,7 +2,6 @@ defmodule Stellar.TxBuild.TransactionSignature do
   @moduledoc """
   A module for tagging and signing transactions.
   """
-  alias Stellar.Network
   alias Stellar.TxBuild.{Transaction, Signature}
 
   alias StellarBase.XDR.{
@@ -17,21 +16,29 @@ defmodule Stellar.TxBuild.TransactionSignature do
   alias StellarBase.XDR.TransactionSignaturePayloadTaggedTransaction, as: TaggedTransaction
 
   @type signatures :: list(Signature.t())
+  @type network_passphrase :: String.t()
 
-  @spec sign(tx :: Transaction.t(), signatures :: signatures()) :: DecoratedSignatures.t()
-  def sign(%Transaction{} = tx, signatures) do
+  @spec sign(
+          tx :: Transaction.t(),
+          signatures :: signatures(),
+          network_passphrase :: network_passphrase()
+        ) :: DecoratedSignatures.t()
+  def sign(%Transaction{} = tx, signatures, network_passphrase) do
     base_signature =
       tx
       |> Transaction.to_xdr()
-      |> base_signature()
+      |> base_signature(network_passphrase)
 
     signatures
     |> Enum.map(&Signature.to_xdr(&1, base_signature))
     |> DecoratedSignatures.new()
   end
 
-  @spec sign_xdr(tx_envelope :: TransactionEnvelope.t(), signature :: Signature.t()) ::
-          DecoratedSignatures.t()
+  @spec sign_xdr(
+          tx_envelope :: TransactionEnvelope.t(),
+          signature :: Signature.t(),
+          network_passphrase :: network_passphrase()
+        ) :: DecoratedSignatures.t()
   def sign_xdr(
         %TransactionEnvelope{
           envelope: %{
@@ -39,35 +46,39 @@ defmodule Stellar.TxBuild.TransactionSignature do
             signatures: %DecoratedSignatures{signatures: current_signatures}
           }
         },
-        %Signature{} = signature
+        %Signature{} = signature,
+        network_passphrase
       ) do
-    base_signature = base_signature(tx_xdr)
+    base_signature = base_signature(tx_xdr, network_passphrase)
 
     signature
     |> Signature.to_xdr(base_signature)
     |> (&DecoratedSignatures.new(current_signatures ++ [&1])).()
   end
 
-  @spec base_signature(tx_xdr :: TransactionXDR.t()) :: binary()
-  def base_signature(%TransactionXDR{} = tx_xdr) do
+  @spec base_signature(tx_xdr :: TransactionXDR.t(), network_passphrase :: network_passphrase()) ::
+          binary()
+  def base_signature(%TransactionXDR{} = tx_xdr, network_passphrase) do
     envelope_type = EnvelopeType.new(:ENVELOPE_TYPE_TX)
 
     tx_xdr
     |> TaggedTransaction.new(envelope_type)
-    |> signature_payload()
+    |> signature_payload(network_passphrase)
   end
 
-  @spec signature_payload(tagged_tx :: struct()) :: binary()
-  defp signature_payload(tagged_tx) do
-    network_id_xdr()
+  @spec signature_payload(tagged_tx :: struct(), network_passphrase :: network_passphrase()) ::
+          binary()
+  defp signature_payload(tagged_tx, network_passphrase) do
+    network_passphrase
+    |> network_id_xdr()
     |> TransactionSignaturePayload.new(tagged_tx)
     |> TransactionSignaturePayload.encode_xdr!()
     |> hash()
   end
 
-  @spec network_id_xdr :: Hash.t()
-  defp network_id_xdr do
-    Network.passphrase()
+  @spec network_id_xdr(network_passphrase :: network_passphrase()) :: Hash.t()
+  defp network_id_xdr(network_passphrase) do
+    network_passphrase
     |> hash()
     |> Hash.new()
   end

--- a/lib/util/network.ex
+++ b/lib/util/network.ex
@@ -40,13 +40,4 @@ defmodule Stellar.Network do
 
   @spec local_horizon_url() :: String.t()
   def local_horizon_url, do: @horizon_urls[:local]
-
-  @spec passphrase() :: String.t()
-  def passphrase do
-    default = @passphrases[:test]
-    Keyword.get(@passphrases, current(), default)
-  end
-
-  @spec current() :: atom()
-  def current, do: Application.get_env(:stellar_sdk, :network, :test)
 end

--- a/lib/util/network.ex
+++ b/lib/util/network.ex
@@ -17,27 +17,34 @@ defmodule Stellar.Network do
     local: "http://localhost:8000"
   ]
 
-  @spec public_passphrase() :: String.t()
+  @type passphrase :: String.t()
+  @type url :: String.t()
+  @type hash :: String.t()
+
+  @spec public_passphrase() :: passphrase()
   def public_passphrase, do: @passphrases[:public]
 
-  @spec testnet_passphrase() :: String.t()
+  @spec testnet_passphrase() :: passphrase()
   def testnet_passphrase, do: @passphrases[:test]
 
-  @spec futurenet_passphrase() :: String.t()
+  @spec futurenet_passphrase() :: passphrase()
   def futurenet_passphrase, do: @passphrases[:future]
 
-  @spec standalone_passphrase() :: String.t()
+  @spec standalone_passphrase() :: passphrase()
   def standalone_passphrase, do: @passphrases[:standalone]
 
-  @spec public_horizon_url() :: String.t()
+  @spec public_horizon_url() :: url()
   def public_horizon_url, do: @horizon_urls[:public]
 
-  @spec testnet_horizon_url() :: String.t()
+  @spec testnet_horizon_url() :: url()
   def testnet_horizon_url, do: @horizon_urls[:test]
 
-  @spec futurenet_horizon_url() :: String.t()
+  @spec futurenet_horizon_url() :: url()
   def futurenet_horizon_url, do: @horizon_urls[:future]
 
-  @spec local_horizon_url() :: String.t()
+  @spec local_horizon_url() :: url()
   def local_horizon_url, do: @horizon_urls[:local]
+
+  @spec network_id(passphrase :: passphrase()) :: hash()
+  def network_id(passphrase), do: :crypto.hash(:sha256, passphrase)
 end

--- a/lib/util/network.ex
+++ b/lib/util/network.ex
@@ -3,6 +3,8 @@ defmodule Stellar.Network do
   Utility that handles Stellar's network configuration.
   """
 
+  alias StellarBase.XDR.Hash
+
   @passphrases [
     public: "Public Global Stellar Network ; September 2015",
     test: "Test SDF Network ; September 2015",
@@ -47,4 +49,11 @@ defmodule Stellar.Network do
 
   @spec network_id(passphrase :: passphrase()) :: hash()
   def network_id(passphrase), do: :crypto.hash(:sha256, passphrase)
+
+  @spec network_id_xdr(passphrase :: passphrase()) :: Hash.t()
+  def network_id_xdr(passphrase) do
+    passphrase
+    |> network_id()
+    |> Hash.new()
+  end
 end

--- a/test/support/xdr_fixtures.ex
+++ b/test/support/xdr_fixtures.ex
@@ -257,11 +257,15 @@ defmodule Stellar.Test.XDRFixtures do
     )
   end
 
-  @spec transaction_envelope_xdr(tx :: Tx.t(), signatures :: list(Signature.t())) ::
+  @spec transaction_envelope_xdr(
+          tx :: Tx.t(),
+          signatures :: list(Signature.t()),
+          network_passphrase :: String.t()
+        ) ::
           TransactionEnvelope.t()
-  def transaction_envelope_xdr(tx, signatures) do
+  def transaction_envelope_xdr(tx, signatures, network_passphrase) do
     envelope_type = EnvelopeType.new(:ENVELOPE_TYPE_TX)
-    decorated_signatures = TransactionSignature.sign(tx, signatures)
+    decorated_signatures = TransactionSignature.sign(tx, signatures, network_passphrase)
 
     tx
     |> Tx.to_xdr()

--- a/test/tx_build/soroban_authorization_entry_test.exs
+++ b/test/tx_build/soroban_authorization_entry_test.exs
@@ -188,14 +188,15 @@ defmodule Stellar.TxBuild.SorobanAuthorizationEntryTest do
       )
   end
 
-  test "sign/2 invalid secret_key", %{
-    soroban_auth_entry_with_address_credentials: soroban_auth_entry_with_address_credentials
+  test "sign/4 invalid secret_key", %{
+    soroban_auth_entry_with_address_credentials: soroban_auth_entry_with_address_credentials,
+    network_passphrase: network_passphrase
   } do
     {:error, :invalid_sign_args} =
-      SorobanAuthorizationEntry.sign(soroban_auth_entry_with_address_credentials, :secret_key)
+      SorobanAuthorizationEntry.sign(soroban_auth_entry_with_address_credentials, :secret_key, network_passphrase)
   end
 
-  test "sign_xdr/3", %{
+  test "sign_xdr/4", %{
     base_64: base_64,
     secret_key: secret_key,
     latest_ledger: latest_ledger,
@@ -206,9 +207,9 @@ defmodule Stellar.TxBuild.SorobanAuthorizationEntryTest do
       SorobanAuthorizationEntry.sign_xdr(base_64, secret_key, latest_ledger, network_passphrase)
   end
 
-  test "sign_xdr/3 invalid secret_key", %{base_64: base_64, latest_ledger: latest_ledger} do
+  test "sign_xdr/4 invalid secret_key", %{base_64: base_64, latest_ledger: latest_ledger, network_passphrase: network_passphrase} do
     {:error, :invalid_sign_args} =
-      SorobanAuthorizationEntry.sign_xdr(base_64, :secret_key, latest_ledger)
+      SorobanAuthorizationEntry.sign_xdr(base_64, :secret_key, latest_ledger, network_passphrase)
   end
 
   test "to_xdr/1", %{soroban_auth_entry: soroban_auth_entry, xdr: xdr} do

--- a/test/tx_build/soroban_authorization_entry_test.exs
+++ b/test/tx_build/soroban_authorization_entry_test.exs
@@ -193,7 +193,11 @@ defmodule Stellar.TxBuild.SorobanAuthorizationEntryTest do
     network_passphrase: network_passphrase
   } do
     {:error, :invalid_sign_args} =
-      SorobanAuthorizationEntry.sign(soroban_auth_entry_with_address_credentials, :secret_key, network_passphrase)
+      SorobanAuthorizationEntry.sign(
+        soroban_auth_entry_with_address_credentials,
+        :secret_key,
+        network_passphrase
+      )
   end
 
   test "sign_xdr/4", %{
@@ -207,7 +211,11 @@ defmodule Stellar.TxBuild.SorobanAuthorizationEntryTest do
       SorobanAuthorizationEntry.sign_xdr(base_64, secret_key, latest_ledger, network_passphrase)
   end
 
-  test "sign_xdr/4 invalid secret_key", %{base_64: base_64, latest_ledger: latest_ledger, network_passphrase: network_passphrase} do
+  test "sign_xdr/4 invalid secret_key", %{
+    base_64: base_64,
+    latest_ledger: latest_ledger,
+    network_passphrase: network_passphrase
+  } do
     {:error, :invalid_sign_args} =
       SorobanAuthorizationEntry.sign_xdr(base_64, :secret_key, latest_ledger, network_passphrase)
   end

--- a/test/tx_build/soroban_authorization_entry_test.exs
+++ b/test/tx_build/soroban_authorization_entry_test.exs
@@ -180,7 +180,12 @@ defmodule Stellar.TxBuild.SorobanAuthorizationEntryTest do
         }
       },
       root_invocation: ^root_invocation
-    } = SorobanAuthorizationEntry.sign(soroban_auth_entry_with_address_credentials, secret_key, network_passphrase)
+    } =
+      SorobanAuthorizationEntry.sign(
+        soroban_auth_entry_with_address_credentials,
+        secret_key,
+        network_passphrase
+      )
   end
 
   test "sign/2 invalid secret_key", %{
@@ -197,7 +202,8 @@ defmodule Stellar.TxBuild.SorobanAuthorizationEntryTest do
     network_passphrase: network_passphrase,
     sign_xdr: sign_xdr
   } do
-    ^sign_xdr = SorobanAuthorizationEntry.sign_xdr(base_64, secret_key, latest_ledger, network_passphrase)
+    ^sign_xdr =
+      SorobanAuthorizationEntry.sign_xdr(base_64, secret_key, latest_ledger, network_passphrase)
   end
 
   test "sign_xdr/3 invalid secret_key", %{base_64: base_64, latest_ledger: latest_ledger} do

--- a/test/tx_build/soroban_authorization_entry_test.exs
+++ b/test/tx_build/soroban_authorization_entry_test.exs
@@ -13,6 +13,8 @@ defmodule Stellar.TxBuild.SorobanAuthorizationEntryTest do
     SorobanCredentials
   }
 
+  alias Stellar.Network
+
   setup do
     fn_args = [SCVal.new(symbol: "dev")]
 
@@ -102,6 +104,7 @@ defmodule Stellar.TxBuild.SorobanAuthorizationEntryTest do
         "AAAAAQAAAAAAAAAAyU545WHCcUig2re/I2xMg5FaqNroaTV+AXQbahq8ftYOvJBkmBOF7wAAAAAAAAABAAAAAAAAAAEJjPko7iuhBRtsY0aDQ2Einilpmj/rDyGds/qx5seSNAAAAANpbmMAAAAAAgAAABIAAAAAAAAAAMlOeOVhwnFIoNq3vyNsTIORWqja6Gk1fgF0G2oavH7WAAAACQAAAAAAAAAAAAAAAAAAAAIAAAAA",
       secret_key: "SCAVFA3PI3MJLTQNMXOUNBSEUOSY66YMG3T2KCQKLQBENNVLVKNPV3EK",
       latest_ledger: 164_256,
+      network_passphrase: Network.testnet_passphrase(),
       sign_xdr:
         "AAAAAQAAAAAAAAAAyU545WHCcUig2re/I2xMg5FaqNroaTV+AXQbahq8ftYOvJBkmBOF7wACgaMAAAAQAAAAAQAAAAEAAAARAAAAAQAAAAIAAAAPAAAACnB1YmxpY19rZXkAAAAAAA0AAAAgyU545WHCcUig2re/I2xMg5FaqNroaTV+AXQbahq8ftYAAAAPAAAACXNpZ25hdHVyZQAAAAAAAA0AAABAIVZ/t4FbgBOE7+B6u41RkQhUrePyoyxrNwGh8oN2HtGtmyuxBwlU49nBUgUwBHmHiQMIMBEW7IbyPNGSuK4YCAAAAAAAAAABCYz5KO4roQUbbGNGg0NhIp4paZo/6w8hnbP6sebHkjQAAAADaW5jAAAAAAIAAAASAAAAAAAAAADJTnjlYcJxSKDat78jbEyDkVqo2uhpNX4BdBtqGrx+1gAAAAkAAAAAAAAAAAAAAAAAAAACAAAAAA==",
       soroban_auth_entry_with_address_credentials: soroban_auth_entry_with_address_credentials,
@@ -133,7 +136,8 @@ defmodule Stellar.TxBuild.SorobanAuthorizationEntryTest do
   test "sign/2", %{
     soroban_auth_entry_with_address_credentials: soroban_auth_entry_with_address_credentials,
     root_invocation: root_invocation,
-    secret_key: secret_key
+    secret_key: secret_key,
+    network_passphrase: network_passphrase
   } do
     %SorobanAuthorizationEntry{
       credentials: %SorobanAddressCredentials{
@@ -176,7 +180,7 @@ defmodule Stellar.TxBuild.SorobanAuthorizationEntryTest do
         }
       },
       root_invocation: ^root_invocation
-    } = SorobanAuthorizationEntry.sign(soroban_auth_entry_with_address_credentials, secret_key)
+    } = SorobanAuthorizationEntry.sign(soroban_auth_entry_with_address_credentials, secret_key, network_passphrase)
   end
 
   test "sign/2 invalid secret_key", %{
@@ -190,9 +194,10 @@ defmodule Stellar.TxBuild.SorobanAuthorizationEntryTest do
     base_64: base_64,
     secret_key: secret_key,
     latest_ledger: latest_ledger,
+    network_passphrase: network_passphrase,
     sign_xdr: sign_xdr
   } do
-    ^sign_xdr = SorobanAuthorizationEntry.sign_xdr(base_64, secret_key, latest_ledger)
+    ^sign_xdr = SorobanAuthorizationEntry.sign_xdr(base_64, secret_key, latest_ledger, network_passphrase)
   end
 
   test "sign_xdr/3 invalid secret_key", %{base_64: base_64, latest_ledger: latest_ledger} do

--- a/test/tx_build/transaction_signature_test.exs
+++ b/test/tx_build/transaction_signature_test.exs
@@ -55,7 +55,13 @@ defmodule Stellar.TxBuild.TransactionSignatureTest do
     signature2 = Signature.new(keypair2)
 
     network_passphrase = Network.testnet_passphrase()
-    tx_envelope = TransactionEnvelope.new(tx: tx, signatures: [signature], network_passphrase: network_passphrase)
+
+    tx_envelope =
+      TransactionEnvelope.new(
+        tx: tx,
+        signatures: [signature],
+        network_passphrase: network_passphrase
+      )
 
     %{
       tx: tx,
@@ -68,7 +74,12 @@ defmodule Stellar.TxBuild.TransactionSignatureTest do
     }
   end
 
-  test "sign/3", %{tx: tx, signatures: signatures, decorated_signature: decorated_signature, network_passphrase: network_passphrase} do
+  test "sign/3", %{
+    tx: tx,
+    signatures: signatures,
+    decorated_signature: decorated_signature,
+    network_passphrase: network_passphrase
+  } do
     %DecoratedSignatures{signatures: [^decorated_signature | _signatures]} =
       TransactionSignature.sign(tx, signatures, network_passphrase)
   end

--- a/test/tx_build/transaction_signature_test.exs
+++ b/test/tx_build/transaction_signature_test.exs
@@ -1,7 +1,7 @@
 defmodule Stellar.TxBuild.TransactionSignatureTest do
   use ExUnit.Case
 
-  alias Stellar.KeyPair
+  alias Stellar.{KeyPair, Network}
 
   alias Stellar.TxBuild.{
     Account,
@@ -54,24 +54,30 @@ defmodule Stellar.TxBuild.TransactionSignatureTest do
     signature = Signature.new(keypair1)
     signature2 = Signature.new(keypair2)
 
-    tx_envelope = TransactionEnvelope.new(tx, [signature])
+    network_passphrase = Network.testnet_passphrase()
+    tx_envelope = TransactionEnvelope.new(tx: tx, signatures: [signature], network_passphrase: network_passphrase)
 
     %{
       tx: tx,
       tx_xdr: tx_xdr,
       tx_envelope: tx_envelope,
       base_signature: base_signature,
+      network_passphrase: network_passphrase,
       decorated_signature: Signature.to_xdr(signature, base_signature),
       signatures: [signature, signature2]
     }
   end
 
-  test "sign/2", %{tx: tx, signatures: signatures, decorated_signature: decorated_signature} do
+  test "sign/3", %{tx: tx, signatures: signatures, decorated_signature: decorated_signature, network_passphrase: network_passphrase} do
     %DecoratedSignatures{signatures: [^decorated_signature | _signatures]} =
-      TransactionSignature.sign(tx, signatures)
+      TransactionSignature.sign(tx, signatures, network_passphrase)
   end
 
-  test "sign_xdr/2", %{tx_envelope: tx_envelope, signatures: [_signature, extra_signature]} do
+  test "sign_xdr/3", %{
+    tx_envelope: tx_envelope,
+    signatures: [_signature, extra_signature],
+    network_passphrase: network_passphrase
+  } do
     %DecoratedSignatures{
       signatures: [
         _signature,
@@ -80,10 +86,14 @@ defmodule Stellar.TxBuild.TransactionSignatureTest do
     } =
       tx_envelope
       |> TransactionEnvelope.to_xdr()
-      |> TransactionSignature.sign_xdr(extra_signature)
+      |> TransactionSignature.sign_xdr(extra_signature, network_passphrase)
   end
 
-  test "base_signature/1", %{tx_xdr: tx_xdr, base_signature: base_signature} do
-    ^base_signature = TransactionSignature.base_signature(tx_xdr)
+  test "base_signature/2", %{
+    tx_xdr: tx_xdr,
+    network_passphrase: network_passphrase,
+    base_signature: base_signature
+  } do
+    ^base_signature = TransactionSignature.base_signature(tx_xdr, network_passphrase)
   end
 end

--- a/test/tx_build/tx_build_test.exs
+++ b/test/tx_build/tx_build_test.exs
@@ -10,6 +10,12 @@ defmodule Stellar.TxBuild.CannedTxBuildImpl do
   end
 
   @impl true
+  def set_network_passphrase(_tx, _network_passphrase) do
+    send(self(), {:set_network_passphrase, "NETWORK_PASSPHRASE_SET"})
+    :ok
+  end
+
+  @impl true
   def add_memo(_tx, _memo) do
     send(self(), {:add_memo, "MEMO_ADDED"})
     :ok
@@ -64,7 +70,7 @@ defmodule Stellar.TxBuild.CannedTxBuildImpl do
   end
 
   @impl true
-  def sign_envelope(_base64, _signatures) do
+  def sign_envelope(_base64, _signatures, _network_passphrase) do
     send(self(), {:sign_envelope, "ENVELOPE_SIGNED"})
     :ok
   end
@@ -153,7 +159,7 @@ defmodule Stellar.TxBuildTest do
   end
 
   test "sign_envelope/2" do
-    Stellar.TxBuild.sign_envelope("AAAAA==", :signature)
+    Stellar.TxBuild.sign_envelope("AAAAA==", :signature, "NETWORK_PASSPHRASE")
     assert_receive({:sign_envelope, "ENVELOPE_SIGNED"})
   end
 

--- a/test/util/network_test.exs
+++ b/test/util/network_test.exs
@@ -2,6 +2,7 @@ defmodule Stellar.NetworkTest do
   use ExUnit.Case
 
   alias Stellar.Network
+  alias StellarBase.XDR.Hash
 
   @public_passphrase "Public Global Stellar Network ; September 2015"
   @testnet_passphrase "Test SDF Network ; September 2015"
@@ -46,6 +47,35 @@ defmodule Stellar.NetworkTest do
 
     test "local_horizon_url/0" do
       @local_horizon_url = Network.local_horizon_url()
+    end
+  end
+
+  describe "network ids" do
+    setup do
+      %{
+        public_network_id:
+          <<122, 195, 57, 151, 84, 78, 49, 117, 210, 102, 189, 2, 36, 57, 178, 44, 219, 22, 80,
+            140, 1, 22, 63, 38, 229, 203, 42, 62, 16, 69, 169, 121>>,
+        test_network_id:
+          <<206, 224, 48, 45, 89, 132, 77, 50, 189, 202, 145, 92, 130, 3, 221, 68, 179, 63, 187,
+            126, 220, 25, 5, 30, 163, 122, 190, 223, 40, 236, 212, 114>>
+      }
+    end
+
+    test "network_id/1 for public network", %{public_network_id: public_network_id} do
+      ^public_network_id = Network.network_id(@public_passphrase)
+    end
+
+    test "network_id_xdr/1 for public network", %{public_network_id: public_network_id} do
+      %Hash{value: ^public_network_id} = Network.network_id_xdr(@public_passphrase)
+    end
+
+    test "network_id/1 for test network", %{test_network_id: test_network_id} do
+      ^test_network_id = Network.network_id(@testnet_passphrase)
+    end
+
+    test "network_id_xdr/1 for test network", %{test_network_id: test_network_id} do
+      %Hash{value: ^test_network_id} = Network.network_id_xdr(@testnet_passphrase)
     end
   end
 end


### PR DESCRIPTION
Contributes to #352 

## TxBuild
- [x] Receive the network_passphase in the TxBuild struct.
- [x] Update the Stellar.Network module to expose the passphases of each network.