### PR TITLE
Update scorecards allowed-endpoints and Security policy

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -31,11 +31,10 @@ jobs:
             api.osv.dev:443
             api.securityscorecards.dev:443
             bestpractices.coreinfrastructure.org:443
-            *.sigstore.dev:443
             github.com:443
-            sigstore-tuf-root.storage.googleapis.com:443
-            oss-fuzz-build-logs.storage.googleapis.com:443
-            www.bestpractices.dev:443
+            *.sigstore.dev:443
+            *.bestpractices.dev:443
+            *.storage.googleapis.com:443
 
       - name: "Checkout code"
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,13 @@
-# Reporting Security Issues
+# Security Policy
 
-To report a security issue, please email [oss@kommit.co](mailto:oss@kommit.co) with a description of the issue, the steps you took to create the issue, affected versions, and, if known, mitigations for the issue.
+## Reporting Security Issues
+
+To report a security issue, you can either:
+- Privately report a vulnerability through repository's Security tab by clicking "Report a vulnerability".
+- Email us at [oss@kommit.co](mailto:oss@kommit.co).
+
+Please, make sure to provide a description of the issue, the steps you took to create the issue, affected versions, and, if known, mitigations for the issue.
+
+## Responsible Disclosure
 
 If the issue is confirmed as a vulnerability, we will open a Security Advisory and acknowledge your contributions as part of it.


### PR DESCRIPTION
Update scorecards allowed-endpoints and Security policy.


The scorecards update is needed to prevent the workflow to fail.

The Security policy is needed to reach the score of 10 in the Scorecard check of `Security-Policy`.
![image](https://github.com/kommitters/stellar_sdk/assets/39246879/bd23c8f6-0bad-45bb-a419-5b20510acb8e)
