### PR TITLE
Delete `config` from `mix.exs` file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add Dynamic network configuration: Now you should provide Horizon URL and Network Passphrase. See [Issue #352](https://github.com/kommitters/stellar_sdk/issues/352).
 * Update all dependencies. See [PR #332](https://github.com/kommitters/stellar_sdk/pull/332).
 * Update scorecards allowed endpoints and Security Policy. See [PR #355](https://github.com/kommitters/stellar_sdk/pull/355).
+* Delete `config` from `mix.exs` file. See [PR #358](https://github.com/kommitters/stellar_sdk/pull/358).
 
 ## 0.20.0 (20.12.2023)
 

--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,7 @@ defmodule Stellar.MixProject do
   defp package do
     [
       description: description(),
-      files: ["lib", "config", "mix.exs", "README*", "LICENSE"],
+      files: ["lib", "mix.exs", "README*", "LICENSE"],
       licenses: ["MIT"],
       links: %{
         "Changelog" => "#{@github_url}/blob/master/CHANGELOG.md",


### PR DESCRIPTION
The workflow to publish on Hex.pm failed with the following error: 
`Missing files: config`
https://github.com/kommitters/stellar_sdk/actions/runs/8143918997