### PR TITLE
Add new async transaction submission endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,6 +583,9 @@ See [**Stellar.Horizon.Accounts**](https://hexdocs.pm/stellar_sdk/Stellar.Horizo
 # submit a transaction
 Stellar.Horizon.Transactions.create(Stellar.Horizon.Server.testnet(), base64_tx_envelope)
 
+# submit a transaction asynchronously
+Stellar.Horizon.Transactions.create_async(Stellar.Horizon.Server.testnet(), base64_tx_envelope)
+
 # retrieve a transaction
 Stellar.Horizon.Transactions.retrieve(Stellar.Horizon.Server.testnet(), "5ebd5c0af4385500b53dd63b0ef5f6e8feef1a7e1c86989be3cdcce825f3c0cc")
 

--- a/lib/horizon/ErrorMapper.ex
+++ b/lib/horizon/ErrorMapper.ex
@@ -1,0 +1,30 @@
+defmodule Stellar.Horizon.ErrorMapper do
+  @moduledoc """
+  Assigns errors returned by the HTTP client to a custom structure.
+  """
+  alias Stellar.Horizon.AsyncTransactionError
+  alias Stellar.Horizon.AsyncTransaction
+  alias Stellar.Horizon.Error
+
+  @type error_source :: :horizon | :network
+  @type error_body :: map() | atom() | String.t()
+  @type error :: {error_source(), error_body()}
+
+  @type t :: {:error, struct()}
+
+  @spec build(error :: error()) :: t()
+  def build(
+        {:horizon,
+         %{hash: _hash, errorResultXdr: _error_result_xdr, tx_status: _tx_status} = decoded_body}
+      ) do
+    error = AsyncTransactionError.new(decoded_body)
+    {:error, error}
+  end
+
+  def build({:horizon, %{hash: _hash, tx_status: _tx_status} = decoded_body}) do
+    error = AsyncTransaction.new(decoded_body)
+    {:error, error}
+  end
+
+  def build(error), do: {:error, Error.new(error)}
+end

--- a/lib/horizon/asyncTransaction.ex
+++ b/lib/horizon/asyncTransaction.ex
@@ -1,0 +1,24 @@
+defmodule Stellar.Horizon.AsyncTransaction do
+  @moduledoc """
+  Represents a `Asynchronous transaction` resource from Horizon API.
+  """
+
+  @behaviour Stellar.Horizon.Resource
+
+  alias Stellar.Horizon.Mapping
+
+  @type t :: %__MODULE__{
+          hash: String.t() | nil,
+          tx_status: String.t() | nil
+        }
+
+  defstruct [
+    :hash,
+    :tx_status
+  ]
+
+  @impl true
+  def new(attrs, opts \\ [])
+
+  def new(attrs, _opts), do: Mapping.build(%__MODULE__{}, attrs)
+end

--- a/lib/horizon/asyncTransactionError.ex
+++ b/lib/horizon/asyncTransactionError.ex
@@ -1,0 +1,26 @@
+defmodule Stellar.Horizon.AsyncTransactionError do
+  @moduledoc """
+  Represents a `Asynchronous transaction error` resource from Horizon API.
+  """
+
+  @behaviour Stellar.Horizon.Resource
+
+  alias Stellar.Horizon.Mapping
+
+  @type t :: %__MODULE__{
+          hash: String.t() | nil,
+          tx_status: String.t() | nil,
+          errorResultXdr: String.t() | nil
+        }
+
+  defstruct [
+    :hash,
+    :tx_status,
+    :errorResultXdr
+  ]
+
+  @impl true
+  def new(attrs, opts \\ [])
+
+  def new(attrs, _opts), do: Mapping.build(%__MODULE__{}, attrs)
+end

--- a/lib/horizon/error.ex
+++ b/lib/horizon/error.ex
@@ -9,6 +9,7 @@ defmodule Stellar.Horizon.Error do
   @type detail :: String.t() | nil
   @type base64_xdr :: String.t()
   @type result_code :: String.t()
+
   @type result_codes :: %{
           optional(:transaction) => result_code(),
           optional(:operations) => list(result_code())
@@ -16,7 +17,8 @@ defmodule Stellar.Horizon.Error do
   @type extras :: %{
           optional(:envelope_xdr) => base64_xdr(),
           optional(:result_codes) => result_codes(),
-          optional(:result_xdr) => base64_xdr()
+          optional(:result_xdr) => base64_xdr(),
+          optional(:error) => detail()
         }
   @type error_source :: :horizon | :network
   @type error_body :: map() | atom() | String.t()
@@ -30,7 +32,13 @@ defmodule Stellar.Horizon.Error do
           extras: extras()
         }
 
-  defstruct [:type, :title, :status_code, :detail, extras: %{}]
+  defstruct [
+    :type,
+    :title,
+    :status_code,
+    :detail,
+    extras: %{}
+  ]
 
   @spec new(error :: error()) :: t()
   def new({:horizon, %{type: type, title: title, status: status_code, detail: detail} = error}) do

--- a/lib/horizon/request.ex
+++ b/lib/horizon/request.ex
@@ -11,7 +11,7 @@ defmodule Stellar.Horizon.Request do
   At a minimum, a request must have the endpoint and method specified to be valid.
   """
 
-  alias Stellar.Horizon.{Collection, Error, Server}
+  alias Stellar.Horizon.{Collection, Server}
   alias Stellar.Horizon.Client, as: Horizon
 
   @type server :: Server.t()
@@ -26,8 +26,8 @@ defmodule Stellar.Horizon.Request do
   @type opts :: Keyword.t()
   @type params :: Keyword.t()
   @type query_params :: list(atom())
-  @type response :: {:ok, map()} | {:error, Error.t()}
-  @type parsed_response :: {:ok, struct()} | {:error, Error.t()}
+  @type response :: {:ok, map()} | {:error, struct()}
+  @type parsed_response :: {:ok, struct()} | {:error, struct()}
 
   @type t :: %__MODULE__{
           method: method(),

--- a/lib/horizon/transactions.ex
+++ b/lib/horizon/transactions.ex
@@ -12,15 +12,24 @@ defmodule Stellar.Horizon.Transactions do
   Horizon API reference: https://developers.stellar.org/api/resources/transactions/
   """
 
-  alias Stellar.Horizon.{Collection, Effect, Error, Operation, Transaction, Request, Server}
+  alias Stellar.Horizon.{
+    Collection,
+    Effect,
+    Operation,
+    Transaction,
+    AsyncTransaction,
+    Request,
+    Server
+  }
 
   @type server :: Server.t()
   @type hash :: String.t()
   @type options :: Keyword.t()
   @type resource :: Transaction.t() | Collection.t()
-  @type response :: {:ok, resource()} | {:error, Error.t()}
+  @type response :: {:ok, resource()} | {:error, struct()}
 
   @endpoint "transactions"
+  @endpoint_async "transactions_async"
 
   @doc """
   Creates a transaction to the Stellar network.
@@ -151,5 +160,28 @@ defmodule Stellar.Horizon.Transactions do
     |> Request.add_query(options, extra_params: [:include_failed, :join])
     |> Request.perform()
     |> Request.results(collection: {Operation, &list_operations(server, hash, &1)})
+  end
+
+  @doc """
+    Creates a transaction to the Stellar network asynchronously.
+
+    ## Parameters:
+      * `server`: The Horizon server to query.
+      * `tx`: The base64-encoded XDR of the transaction.
+
+    ## Examples
+
+        iex> Transactions.create_async(Stellar.Horizon.Server.testnet(), "AAAAAgAAAACQcEK2yfQA9CHrX+2UMkRIb/1wzltKqHpbdIcJbp+b/QAAAGQAAiEYAAAAAQAAAAEAAAAAAAAAAAAAAABgXP3QAAAAAQAAABBUZXN0IFRyYW5zYWN0aW9uAAAAAQAAAAAAAAABAAAAAJBwQrbJ9AD0Ietf7ZQyREhv/XDOW0qoelt0hwlun5v9AAAAAAAAAAAF9eEAAAAAAAAAAAFun5v9AAAAQKdJnG8QRiv9xGp1Oq7ACv/xR2BnNqjfUHrGNua7m4tWbrun3+GmAj6ca3xz+4ZppWRTbvTUcCxvpbHERZ85QgY=")
+        {:ok, %AsyncTransaction{}}
+  """
+  @spec create_async(server :: server(), base64_envelope :: String.t()) :: response()
+  def create_async(server, base64_envelope) do
+
+    server
+    |> Request.new(:post, @endpoint_async)
+    |> Request.add_headers([{"Content-Type", "application/x-www-form-urlencoded"}])
+    |> Request.add_body(tx: base64_envelope)
+    |> Request.perform()
+    |> Request.results(as: AsyncTransaction)
   end
 end

--- a/lib/horizon/transactions.ex
+++ b/lib/horizon/transactions.ex
@@ -176,7 +176,6 @@ defmodule Stellar.Horizon.Transactions do
   """
   @spec create_async(server :: server(), base64_envelope :: String.t()) :: response()
   def create_async(server, base64_envelope) do
-
     server
     |> Request.new(:post, @endpoint_async)
     |> Request.add_headers([{"Content-Type", "application/x-www-form-urlencoded"}])

--- a/test/horizon/async_transaction_test.exs
+++ b/test/horizon/async_transaction_test.exs
@@ -1,0 +1,30 @@
+defmodule Stellar.Horizon.AsyncTransactionTest do
+  use ExUnit.Case
+
+  alias Stellar.Test.Fixtures.Horizon
+
+  alias Stellar.Horizon.{
+    AsyncTransaction
+  }
+
+  setup do
+    json_body = Horizon.fixture("async_transaction")
+    attrs = Jason.decode!(json_body, keys: :atoms)
+
+    %{attrs: attrs}
+  end
+
+  test "new/2", %{attrs: attrs} do
+    %AsyncTransaction{
+      hash: "12958c37b341802a19ddada4c2a56b453a9cba728b2eefdfbc0b622e37379222",
+      tx_status: "PENDING"
+    } = AsyncTransaction.new(attrs)
+  end
+
+  test "new/2 empty_attrs" do
+    %AsyncTransaction{
+      hash: nil,
+      tx_status: nil
+    } = AsyncTransaction.new(%{})
+  end
+end

--- a/test/horizon/async_transaction_test.exs
+++ b/test/horizon/async_transaction_test.exs
@@ -3,9 +3,7 @@ defmodule Stellar.Horizon.AsyncTransactionTest do
 
   alias Stellar.Test.Fixtures.Horizon
 
-  alias Stellar.Horizon.{
-    AsyncTransaction
-  }
+  alias Stellar.Horizon.AsyncTransaction
 
   setup do
     json_body = Horizon.fixture("async_transaction")

--- a/test/support/fixtures/horizon/400_async_transaction_error_result_xdr.json
+++ b/test/support/fixtures/horizon/400_async_transaction_error_result_xdr.json
@@ -1,0 +1,5 @@
+{
+  "errorResultXdr": "AAAAAAAAAGT////6AAAAAA==",
+  "tx_status": "ERROR",
+  "hash": "12958c37b341802a19ddada4c2a56b453a9cba728b2eefdfbc0b622e37379222"
+}

--- a/test/support/fixtures/horizon/400_transaction_malformed.json
+++ b/test/support/fixtures/horizon/400_transaction_malformed.json
@@ -1,0 +1,10 @@
+{
+  "type": "https://stellar.org/horizon-errors/transaction_malformed",
+  "title": "Transaction Malformed",
+  "status": 400,
+  "detail": "Horizon could not decode the transaction envelope in this request. A transaction should be an XDR TransactionEnvelope struct encoded using base64.  The envelope read from this request is echoed in the `extras.envelope_xdr` field of this response for your convenience.",
+  "extras": {
+    "envelope_xdr": "tx_malformed",
+    "error": {}
+  }
+}

--- a/test/support/fixtures/horizon/409_async_transaction_duplicate.json
+++ b/test/support/fixtures/horizon/409_async_transaction_duplicate.json
@@ -1,0 +1,4 @@
+{
+  "tx_status": "DUPLICATE",
+  "hash": "822a283337b124f82b0b8725b39738d2f3e86b699e25b9b646809336384bf41c"
+}

--- a/test/support/fixtures/horizon/409_async_transaction_try_again_later.json
+++ b/test/support/fixtures/horizon/409_async_transaction_try_again_later.json
@@ -1,0 +1,4 @@
+{
+  "tx_status": "TRY_AGAIN_LATER",
+  "hash": "822a283337b124f82b0b8725b39738d2f3e86b699e25b9b646809336384bf41c"
+}

--- a/test/support/fixtures/horizon/async_transaction.json
+++ b/test/support/fixtures/horizon/async_transaction.json
@@ -1,0 +1,4 @@
+{
+   "tx_status": "PENDING",
+   "hash": "12958c37b341802a19ddada4c2a56b453a9cba728b2eefdfbc0b622e37379222"
+}


### PR DESCRIPTION
### Description

In this PR, the function `create_async` was created that allows to submit a transaction asynchronously that supports the new endpoint `POST /transactions_async`

**Note**: This PR was created in base to https://github.com/kommitters/stellar_sdk/pull/371