### PR TITLE
Add hash to handle transaction timeout response

### DIFF
--- a/lib/horizon/error.ex
+++ b/lib/horizon/error.ex
@@ -15,6 +15,7 @@ defmodule Stellar.Horizon.Error do
           optional(:operations) => list(result_code())
         }
   @type extras :: %{
+          optional(:hash) => base64_xdr(),
           optional(:envelope_xdr) => base64_xdr(),
           optional(:result_codes) => result_codes(),
           optional(:result_xdr) => base64_xdr(),

--- a/lib/horizon/error.ex
+++ b/lib/horizon/error.ex
@@ -9,13 +9,14 @@ defmodule Stellar.Horizon.Error do
   @type detail :: String.t() | nil
   @type base64_xdr :: String.t()
   @type result_code :: String.t()
+  @type hash :: String.t()
 
   @type result_codes :: %{
           optional(:transaction) => result_code(),
           optional(:operations) => list(result_code())
         }
   @type extras :: %{
-          optional(:hash) => base64_xdr(),
+          optional(:hash) => hash(),
           optional(:envelope_xdr) => base64_xdr(),
           optional(:result_codes) => result_codes(),
           optional(:result_xdr) => base64_xdr(),

--- a/test/horizon/client/default_test.exs
+++ b/test/horizon/client/default_test.exs
@@ -104,8 +104,15 @@ defmodule Stellar.Horizon.Client.DefaultTest do
     end
 
     test "timeout", %{server: server} do
-      {:error, %Error{title: "Timeout", status_code: 504}} =
-        Default.request(server, :post, "/transactions?tx=timeout")
+      {:error,
+       %Error{
+         title: "Transaction Submission Timeout",
+         status_code: 504,
+         extras: %{
+           hash: _hash,
+           envelope_xdr: _envelope_xdr
+         }
+       }} = Default.request(server, :post, "/transactions?tx=timeout")
     end
 
     test "network_error", %{server: server} do

--- a/test/support/fixtures/horizon/504.json
+++ b/test/support/fixtures/horizon/504.json
@@ -1,6 +1,10 @@
 {
-  "type": "https://stellar.org/horizon-errors/timeout",
-  "title": "Timeout",
+  "type": "https://developers.stellar.org/docs/data/horizon/api-reference/errors/http-status-codes/horizon-specific/timeout",
+  "title": "Transaction Submission Timeout",
   "status": 504,
-  "detail": "Your request timed out before completing.  Please try your request again. If you are submitting a transaction make sure you are sending exactly the same transaction (with the same sequence number)."
+  "detail": "Your transaction submission request has timed out. This does not necessarily mean the submission has failed. Before resubmitting, please use the transaction hash provided in `extras.hash` to poll the GET /transactions endpoint for sometime and check if it was included in a ledger.",
+  "extras": {
+    "hash": "12958c37b341802a19ddada4c2a56b453a9cba728b2eefdfbc0b622e37379222",
+    "envelope_xdr": "AAAAAJ2kP2xLaOVLj6DRwX1mMyA0mubYnYvu0g8OdoDqxXuFAAAAZADjfzAACzBMAAAAAQAAAAAAAAAAAAAAAF4vYIYAAAABAAAABjI5ODQyNAAAAAAAAQAAAAAAAAABAAAAAKdeYELovtcnTxqPEVsdbxHLMoMRalZsK7lo/+3ARzUZAAAAAAAAAADUFJPYAAAAAAAAAAHqxXuFAAAAQBpLpQyh+mwDd5nDSxTaAh5wopBBUaSD1eOK9MdiO+4kWKVTqSr/Ko3kYE/+J42Opsewf81TwINONPbY2CtPggE="
+  }
 }


### PR DESCRIPTION
### Description 
In this PR was added the hash type in Error module to handle the transaction timeout response in base to this implementation https://github.com/stellar/go/pull/5328

